### PR TITLE
First PoC for dockerv2

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -29,7 +29,7 @@ func init() {
 	})
 }
 
-var allOptions = []string{"host", "gometa", "www"}
+var allOptions = []string{"host", "gometa", "www", "dockerv2"}
 
 func parse(c *caddy.Controller) (txtdirect.Config, error) {
 	var enable []string

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -111,7 +111,7 @@ func TestParse(t *testing.T) {
 			`,
 			false,
 			txtdirect.Config{
-				Enable: []string{"gometa", "www"},
+				Enable: []string{"gometa", "www", "dockerv2"},
 			},
 		},
 		{

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2017 - The TXTdirect Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package txtdirect
+
+import "net/http"
+import "fmt"
+
+func dockerv2(w http.ResponseWriter, r *http.Request, rec record) error {
+	path := r.URL.Path
+
+	if path == "/v2/" {
+		_, err := w.Write([]byte(http.StatusText(http.StatusOK)))
+		return err
+	}
+
+	return fmt.Errorf("Unhandled dockerv2 case")
+}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -167,5 +167,9 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		return gometa(w, rec, host, path)
 	}
 
+	if rec.Type == "dockerv2" {
+		return dockerv2(w, r, rec)
+	}
+
 	return fmt.Errorf("record type %s unsupported", rec.Type)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Adds dockerv2 type for container vanity urls.

**Special notes for your reviewer**:
PoC for public containers only.

**Release note**:
```release-note
Container vanity url support with dockerv2 type and docker registry api v2.
```
