### PR TITLE
Move CI build logic entirely in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,28 +14,10 @@ jobs:
     - stage: deploy
       script:
         # build caddy
-        - go get github.com/mholt/caddy/caddy
-        - go get github.com/caddyserver/builds
-        - go get github.com/miekg/caddy-prometheus
-        - go get github.com/captncraig/caddy-realip
-        - go get -d -u
-        - cd $GOPATH/src/github.com/mholt/caddy
-        - find caddyhttp/httpserver -name 'plugin.go' -type f -exec sed -i -e "s/gopkg/txtdirect/g" -- {} +
-        - find caddy/caddymain -name 'run.go' -type f -exec sed -i -e "s/\/\/ This is where other plugins get plugged in (imported)/_ \"github.com\/txtdirect\/txtdirect\/caddy\"/g" -- {} +
-        - find caddy/caddymain -name 'run.go' -type f -exec sed -i -e '/_ "github.com\/txtdirect\/txtdirect\/caddy"/a _ "github.com\/miekg\/caddy-prometheus"' -- {} +
-        - find caddy/caddymain -name 'run.go' -type f -exec sed -i -e '/_ "github.com\/txtdirect\/txtdirect\/caddy"/a _ "github.com\/captncraig\/caddy-realip"' -- {} +
-        - cd caddy
-        - CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w"
-        # add write Dockerfile
-        - echo "FROM alpine:3.6" > Dockerfile
-        - echo "RUN apk --no-cache add ca-certificates" >> Dockerfile
-        - echo "ADD caddy /caddy" >> Dockerfile
-        - echo "CMD [\"/caddy\"]" >> Dockerfile
+        - make travis-build
         # build image and push
         - docker login --username="$DOCKER_USER" --password="$DOCKER_PASSWORD"
-        - BUILD_REF=`echo $TRAVIS_COMMIT | cut -c1-6`
-        - TAG=`if [ -n "$TRAVIS_TAG" ]; then echo $TRAVIS_TAG; else echo dev; fi`
-        - docker build -t seetheprogress/txtdirect:$TAG-$BUILD_REF -f Dockerfile .
-        - docker push seetheprogress/txtdirect:$TAG-$BUILD_REF
+        - make docker
+        - make docker-push
 
       go: 1.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ go:
 services:
   - docker
 
+script:
+  - make travis-build
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 BIN=txtdirect
+TAG=$(if $(TRAVIS_TAG),$(TRAVIS_TAG),dev)
+COMMIT=$(if $(TRAVIS_COMMIT),$(TRAVIS_COMMIT),$(shell git rev-parse HEAD))
+BUILD_REF=$(shell echo $(COMMIT) | cut -c1-6)
 
-all:
-	go get github.com/mholt/caddy/caddy
-	go get github.com/caddyserver/builds
-	go get github.com/miekg/caddy-prometheus
-	go get github.com/captncraig/caddy-realip
-	go get -d -u
+build: fetch-dependencies
 	rm -rf caddy-copy
 	git clone https://github.com/mholt/caddy caddy-copy
 	find caddy-copy/caddyhttp/httpserver -name 'plugin.go' -type f -exec sed -i -e "s/gopkg/txtdirect/g" -- {} +
@@ -16,5 +14,25 @@ all:
 	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w"
 	mv caddy-copy/caddy/caddy ./$(BIN)
 
-docker: all
-	docker build -t seetheprogress/txtdirect:dev-$$(git rev-parse HEAD | cut -c1-6) .
+travis-build: fetch-dependencies
+	cd $$GOPATH/src/github.com/mholt/caddy && \
+	find caddyhttp/httpserver -name 'plugin.go' -type f -exec sed -i -e "s/gopkg/txtdirect/g" -- {} + && \
+	find caddy/caddymain -name 'run.go' -type f -exec sed -i -e "s/\/\/ This is where other plugins get plugged in (imported)/_ \"github.com\/txtdirect\/txtdirect\/caddy\"/g" -- {} + && \
+	find caddy/caddymain -name 'run.go' -type f -exec sed -i -e '/_ "github.com\/txtdirect\/txtdirect\/caddy"/a _ "github.com\/miekg\/caddy-prometheus"' -- {} + && \
+	find caddy/caddymain -name 'run.go' -type f -exec sed -i -e '/_ "github.com\/txtdirect\/txtdirect\/caddy"/a _ "github.com\/captncraig\/caddy-realip"' -- {} + && \
+	cd caddy && \
+	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w"
+	mv $$GOPATH/src/github.com/mholt/caddy/caddy/caddy txtdirect
+
+fetch-dependencies:
+	go get github.com/mholt/caddy/caddy
+	go get github.com/caddyserver/builds
+	go get github.com/miekg/caddy-prometheus
+	go get github.com/captncraig/caddy-realip
+	go get -d -u
+
+docker:
+	docker build -t seetheprogress/txtdirect:$(TAG)-$(BUILD_REF) .
+
+docker-push:
+	docker push seetheprogress/txtdirect:$(TAG)-$(BUILD_REF)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Moves build logic for Travis CI to Makefile

**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #30

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note
Move CI build logic to Makefile
```
