### PR TITLE
Change DNS TXT lookup to use the absolute zone

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -103,7 +103,13 @@ func getBaseTarget(rec record) (string, int) {
 
 func getRecord(host, path string) (record, error) {
 	zone := strings.Join([]string{basezone, host}, ".")
-	s, err := net.LookupTXT(zone)
+	var absoluteZone string
+	if strings.HasSuffix(zone, ".") {
+		absoluteZone = zone
+	} else {
+		absoluteZone = strings.Join([]string{zone, "."}, "")
+	}
+	s, err := net.LookupTXT(absoluteZone)
 	if err != nil {
 		return record{}, fmt.Errorf("could not get TXT record: %s", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the DNS TXT lookup to add a trailing dot to the end of the zone in order to speed up lookup requests by avoiding the use of the entire DNS search path.

**Which issue this PR fixes**:
fixes #43 
