### PR TITLE
Remove port if host includes one

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -14,6 +14,7 @@ limitations under the License.
 package txtdirect
 
 import (
+	"net/url"
 	"fmt"
 	"log"
 	"net"
@@ -102,6 +103,10 @@ func getBaseTarget(rec record) (string, int) {
 }
 
 func getRecord(host, path string) (record, error) {
+	if strings.Contains(host, ":") {
+		hostSlice := strings.Split(host, ":")
+		host = hostSlice[0]
+	}
 	zone := strings.Join([]string{basezone, host}, ".")
 	s, err := net.LookupTXT(zone)
 	if err != nil {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -14,7 +14,6 @@ limitations under the License.
 package txtdirect
 
 import (
-	"net/url"
 	"fmt"
 	"log"
 	"net"


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks if the host variable contains a port and removes it before use in zone since adding a port to the zone will cause it to break.

**Which issue this PR fixes**:
fixes #39 
