### PR TITLE
Prevent internal folder path

### DIFF
--- a/gometa.go
+++ b/gometa.go
@@ -14,6 +14,8 @@ limitations under the License.
 package txtdirect
 
 import (
+	"fmt"
+	"strings"
 	"html/template"
 	"net/http"
 )
@@ -28,6 +30,10 @@ var tmpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
 func gometa(w http.ResponseWriter, r record, host, path string) error {
 	if path == "/" {
 		path = ""
+	}
+	bl := "/internal"
+	if strings.Contains(path, bl) {
+		return fmt.Errorf("path containing 'internal' is disallowed")
 	}
 
 	return tmpl.Execute(w, struct {

--- a/path.go
+++ b/path.go
@@ -8,10 +8,6 @@ import (
 )
 
 func zoneFromPath(host string, path string) (string, int, error) {
-	bl := "/internal"
-	if strings.Contains(path, bl) {
-		return "", 0, fmt.Errorf("path containing 'internal' is disallowed")
-	}
 	match, err := regexp.Compile("([a-zA-Z0-9]+)")
 	if err != nil {
 		return "", 0, err

--- a/path.go
+++ b/path.go
@@ -8,6 +8,10 @@ import (
 )
 
 func zoneFromPath(host string, path string) (string, int, error) {
+	bl := "/internal"
+	if strings.Contains(path, bl) {
+		return "", 0, fmt.Errorf("path containing 'internal' is disallowed")
+	}
 	match, err := regexp.Compile("([a-zA-Z0-9]+)")
 	if err != nil {
 		return "", 0, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds checks for paths that contain "internal" folders and returns an error since importing of internal packages should be prevented.

**Which issue this PR fixes**:
fixes #27 