### PR TITLE
Addresses multiple _redirect records and maximum _redirect length

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -122,7 +122,7 @@ func getRecord(host, path string) (record, error) {
 	}
 
 	if len(s) != 1 {
-		return record{}, fmt.Errorf("could not parse TXT record with %d redirects", len(s))
+		return record{}, fmt.Errorf("could not parse TXT record with %d records", len(s))
 	}
 
 	rec := record{}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -82,6 +82,10 @@ func (r *record) Parse(str string) error {
 			}
 			r.To = l
 		}
+		if len(l) > 255 {
+			return fmt.Errorf("TXT record cannot exceed the maximum of 255 characters")
+		}
+
 	}
 
 	if r.Code == 0 {
@@ -116,6 +120,10 @@ func getRecord(host, path string) (record, error) {
 
 	if err != nil {
 		return record{}, fmt.Errorf("could not get TXT record: %s", err)
+	}
+
+	if len(s) != 1 {
+		return record{}, fmt.Errorf("could not parse TXT record with %d redirects", len(s))
 	}
 
 	rec := record{}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -85,7 +85,6 @@ func (r *record) Parse(str string) error {
 		if len(l) > 255 {
 			return fmt.Errorf("TXT record cannot exceed the maximum of 255 characters")
 		}
-
 	}
 
 	if r.Code == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we only check the first _redirect TXT record, if multiple _redirect records are provided, TXTDirect will only choose the first record. To address this issue, it is necessary to check the slice of TXT records and if it does not equal 1, we now return an error. 

Also, the maximum length of a _redirect record cannot exceed 255 characters. This PR addresses that issue as well by returning an error when a _redirect record exceeds 255 characters.

**Which issue this PR fixes**:
fixes #40 