### PR TITLE
Disable caddy telemetry in Travis build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,21 +6,22 @@ BUILD_REF=$(shell echo $(COMMIT) | cut -c1-6)
 build: fetch-dependencies
 	rm -rf caddy-copy
 	git clone https://github.com/mholt/caddy caddy-copy
-	find caddy-copy/caddyhttp/httpserver -name 'plugin.go' -type f -exec sed -i -e "s/gopkg/txtdirect/g" -- {} +
-	find caddy-copy/caddy/caddymain -name 'run.go' -type f -exec sed -i -e "s/\/\/ This is where other plugins get plugged in (imported)/_ \"github.com\/txtdirect\/txtdirect\/caddy\"/g" -- {} +
+	find caddy-copy/caddyhttp/httpserver -name 'plugin.go' -type f -exec sed -i -e "s/gopkg/txtdirect/" -- {} +
+	find caddy-copy/caddy/caddymain -name 'run.go' -type f -exec sed -i -e "s/\/\/ This is where other plugins get plugged in (imported)/_ \"github.com\/txtdirect\/txtdirect\/caddy\"/" -- {} +
 	find caddy-copy/caddy/caddymain -name 'run.go' -type f -exec sed -i -e '/_ "github.com\/txtdirect\/txtdirect\/caddy"/a _ "github.com\/miekg\/caddy-prometheus"' -- {} +
 	find caddy-copy/caddy/caddymain -name 'run.go' -type f -exec sed -i -e '/_ "github.com\/txtdirect\/txtdirect\/caddy"/a _ "github.com\/captncraig\/caddy-realip"' -- {} +
-	find caddy-copy/caddy/caddymain -name 'run.go' -type f -exec sed -i -e 's/const enableTelemetry = true/const enableTelemetry = false/g' -- {} +
+	find caddy-copy/caddy/caddymain -name 'run.go' -type f -exec sed -i -e 's/const enableTelemetry = true/const enableTelemetry = false/' -- {} +
 	cd caddy-copy/caddy && \
 	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w"
 	mv caddy-copy/caddy/caddy ./$(BIN)
 
 travis-build: fetch-dependencies
 	cd $$GOPATH/src/github.com/mholt/caddy && \
-	find caddyhttp/httpserver -name 'plugin.go' -type f -exec sed -i -e "s/gopkg/txtdirect/g" -- {} + && \
-	find caddy/caddymain -name 'run.go' -type f -exec sed -i -e "s/\/\/ This is where other plugins get plugged in (imported)/_ \"github.com\/txtdirect\/txtdirect\/caddy\"/g" -- {} + && \
+	find caddyhttp/httpserver -name 'plugin.go' -type f -exec sed -i -e "s/gopkg/txtdirect/" -- {} + && \
+	find caddy/caddymain -name 'run.go' -type f -exec sed -i -e "s/\/\/ This is where other plugins get plugged in (imported)/_ \"github.com\/txtdirect\/txtdirect\/caddy\"/" -- {} + && \
 	find caddy/caddymain -name 'run.go' -type f -exec sed -i -e '/_ "github.com\/txtdirect\/txtdirect\/caddy"/a _ "github.com\/miekg\/caddy-prometheus"' -- {} + && \
 	find caddy/caddymain -name 'run.go' -type f -exec sed -i -e '/_ "github.com\/txtdirect\/txtdirect\/caddy"/a _ "github.com\/captncraig\/caddy-realip"' -- {} + && \
+	find caddy/caddymain -name 'run.go' -type f -exec sed -i -e 's/const enableTelemetry = true/const enableTelemetry = false/' -- {} + && \
 	cd caddy && \
 	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w"
 	mv $$GOPATH/src/github.com/mholt/caddy/caddy/caddy txtdirect


### PR DESCRIPTION
**What this PR does / why we need it**:
Disables caddy telemetry in Travis build. Also removes the unnecessary 'g' in the regex.

**Which issue this PR fixes**:
fixes #48 