### PR TITLE
Add test for 'internal' folder in path

### DIFF
--- a/gometa_test.go
+++ b/gometa_test.go
@@ -84,3 +84,11 @@ func TestGometa(t *testing.T) {
 		}
 	}
 }
+
+func TestInternalFolderInPath(t *testing.T) {
+	rec := httptest.NewRecorder()
+	err := gometa(rec, record{}, "example.com", "/test/internal")
+	if err == nil {
+		t.Errorf("Expected to get an error when '/internal' folder included in path")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a test that ensures an error is returned when "/internal" is included in the path.