### PR TITLE
Fix getFinalRecord to find the final non-path record

### DIFF
--- a/path.go
+++ b/path.go
@@ -79,7 +79,7 @@ func getFinalRecord(zone string, from int) (record, error) {
 		}
 		zone, from, err := zoneFromPath(url.Host, url.Path, rec)
 		if err != nil {
-			return rec, fmt.Errorf("could not generate zone URI from path. %s", err)
+			return rec, fmt.Errorf("could not generate zone URI from path: %s", err)
 		}
 		rec, err = getFinalRecord(zone, from)
 	}

--- a/path.go
+++ b/path.go
@@ -82,6 +82,9 @@ func getFinalRecord(zone string, from int) (record, error) {
 			return rec, fmt.Errorf("could not generate zone URI from path: %s", err)
 		}
 		rec, err = getFinalRecord(zone, from)
+		if err != nil {
+			return rec, fmt.Errorf("could not find the final record: %s", err)
+		}
 	}
 
 	return rec, nil

--- a/path.go
+++ b/path.go
@@ -3,7 +3,6 @@ package txtdirect
 import (
 	"fmt"
 	"net"
-	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -73,18 +72,7 @@ func getFinalRecord(zone string, from int) (record, error) {
 	}
 
 	if rec.Type == "path" {
-		url, err := url.Parse(rec.To)
-		if err != nil {
-			return rec, fmt.Errorf("could not parse the url: %s", err)
-		}
-		zone, from, err := zoneFromPath(url.Host, url.Path, rec)
-		if err != nil {
-			return rec, fmt.Errorf("could not generate zone URI from path: %s", err)
-		}
-		rec, err = getFinalRecord(zone, from)
-		if err != nil {
-			return rec, fmt.Errorf("could not find the final record: %s", err)
-		}
+		return rec, fmt.Errorf("chaining path is not currently supported")
 	}
 
 	return rec, nil

--- a/path.go
+++ b/path.go
@@ -3,6 +3,7 @@ package txtdirect
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -69,6 +70,18 @@ func getFinalRecord(zone string, from int) (record, error) {
 	rec := record{}
 	if err = rec.Parse(txts[0]); err != nil {
 		return rec, fmt.Errorf("could not parse record: %s", err)
+	}
+
+	if rec.Type == "path" {
+		url, err := url.Parse(rec.To)
+		if err != nil {
+			return rec, fmt.Errorf("could not parse the url: %s", err)
+		}
+		zone, from, err := zoneFromPath(url.Host, url.Path, rec)
+		if err != nil {
+			return rec, fmt.Errorf("could not generate zone URI from path. %s", err)
+		}
+		rec, err = getFinalRecord(zone, from)
 	}
 
 	return rec, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix getFinalRecord to find the final non-path record

**Which issue this PR fixes**:
fixes #59 


**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
