### PR TITLE
Fix index out of range in zoneFromPath

### DIFF
--- a/path.go
+++ b/path.go
@@ -31,6 +31,9 @@ func zoneFromPath(host string, path string, rec record) (string, int, error) {
 		for k := range fromSlice {
 			keys = append(keys, k)
 		}
+		if len(keys) != len(pathSlice) {
+			return "", 0, fmt.Errorf("length of path doesn't match with length of from= in record")
+		}
 		generatedPath := []string{}
 
 		sort.Sort(sort.Reverse(sort.IntSlice(keys)))

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -194,9 +194,10 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 			return nil
 		}
 		if path != "" {
-			zone, from, _ := zoneFromPath(host, path, rec)
+			zone, from, err := zoneFromPath(host, path, rec)
 			rec, err = getFinalRecord(zone, from)
 			if err != nil {
+				log.Print("Fallback is triggerd because an error has occurred: ", err)
 				if fallback != "" {
 					http.Redirect(w, r, fallback, code)
 				} else if c.Redirect != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix index out of range in zoneFromPath when the length of path doesn't match with length of from= in record

**Which issue this PR fixes**:
fixes #69 


**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
