### PR TITLE
Remove rewriting rec.To when it doesn't exist

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -153,11 +153,6 @@ func getRecord(host, path string, ctx context.Context, c Config) (record, error)
 		return rec, fmt.Errorf("could not parse record: %s", err)
 	}
 
-	if rec.To == "" {
-		s := []string{defaultProtocol, "://", defaultSub, ".", host}
-		rec.To = strings.Join(s, "")
-	}
-
 	return rec, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove rewriting rec.To when it doesn't exist

**Which issue this PR fixes**:
fixes #81 

**Special notes for your reviewer**:

**Release note**:

```release-note

```
