### PR TITLE
Add wrapper function for absolute zone and dialer code

### DIFF
--- a/path.go
+++ b/path.go
@@ -54,14 +54,9 @@ func zoneFromPath(host string, path string, rec record) (string, int, error) {
 }
 
 func getFinalRecord(zone string, from int, ctx context.Context, c Config) (record, error) {
-	var txts []string
-	var err error
-
-	if c.Resolver != "" {
-		net := customResolver(c)
-		txts, err = net.LookupTXT(ctx, zone)
-	} else {
-		txts, err = net.LookupTXT(zone)
+	txts, err := query(zone, ctx, c)
+	if err != nil {
+		return record{}, err
 	}
 
 	// if nothing found, jump into wildcards


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a wrapper function so that all DNS requests use an absolute zone and also uses the custom or non-custom dialer where applicable.

**Which issue this PR fixes**:
fixes #85 