### PR TITLE
Implement {uri} placeholder

### DIFF
--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -257,3 +257,29 @@ func TestRedirectBlacklist(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err)
 	}
 }
+
+func TestParsePlaceholders(t *testing.T) {
+	tests := []struct {
+		url         string
+		placeholder string
+		expected    string
+	}{
+		{
+			"example.com{uri}",
+			"?test=test",
+			"example.com?test=test",
+		},
+		{
+			"example.com/{uri}/{uri}",
+			"?test=test",
+			"example.com/?test=test/?test=test",
+		},
+	}
+	for _, test := range tests {
+		req := httptest.NewRequest("GET", "https://example.com"+test.placeholder, nil)
+		result := parsePlaceholders(test.url, req)
+		if result != test.expected {
+			t.Errorf("Expected %s, got %s", test.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements {uri} placeholder. We can also move these util functions into another package to make the main file cleaner if it makes sense.

**Which issue this PR fixes**:
fixes #82 
