### PR TITLE
Include leading slash in URI and Path placeholders

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -131,8 +131,7 @@ func parsePlaceholders(input string, r *http.Request) string {
 	for _, placeholder := range placeholders {
 		switch placeholder[0] {
 		case "{uri}":
-			uri := []rune(r.URL.RequestURI())
-			input = strings.Replace(input, "{uri}", string(uri[1:]), -1)
+			input = strings.Replace(input, "{uri}", r.URL.RequestURI(), -1)
 		case "{dir}":
 			dir, _ := path.Split(r.URL.Path)
 			input = strings.Replace(input, "{dir}", dir, -1)
@@ -148,7 +147,7 @@ func parsePlaceholders(input string, r *http.Request) string {
 		case "{method}":
 			input = strings.Replace(input, "{method}", r.Method, -1)
 		case "{path}":
-			input = strings.Replace(input, "{path}", r.URL.Path[1:], -1)
+			input = strings.Replace(input, "{path}", r.URL.Path, -1)
 		case "{path_escaped}":
 			input = strings.Replace(input, "{path_escaped}", url.QueryEscape(r.URL.Path), -1)
 		case "{port}":

--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -266,27 +266,22 @@ func TestParsePlaceholders(t *testing.T) {
 	}{
 		{
 			"example.com{uri}",
-			"?test=test",
-			"example.com?test=test",
+			"/?test=test",
+			"example.com/?test=test",
 		},
 		{
-			"example.com/{uri}/{uri}",
-			"?test=test",
-			"example.com/?test=test/?test=test",
-		},
-		{
-			"example.com/{uri}/{~test}",
-			"?test=test",
+			"example.com{uri}/{~test}",
+			"/?test=test",
 			"example.com/?test=test/test",
 		},
 		{
-			"example.com/{uri}/{>Test}",
-			"?test=test",
+			"example.com{uri}/{>Test}",
+			"/?test=test",
 			"example.com/?test=test/test-header",
 		},
 		{
-			"example.com/{uri}/{?test}",
-			"?test=test",
+			"example.com{uri}/{?test}",
+			"/?test=test",
 			"example.com/?test=test/test",
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Fixes a potential bug/misunderstanding with how we handle absolute paths in placeholders. 

Previously the leading `/` would be trimmed, now we keep it. This brings us closer to caddy's behaviour for [placeholders](https://caddyserver.com/docs/placeholders).
