### PR TITLE
Refactor query to globally remove port from zone and use absolute zone

### DIFF
--- a/path.go
+++ b/path.go
@@ -1,10 +1,8 @@
 package txtdirect
 
 import (
-	"context"
 	"fmt"
 	"log"
-	"net"
 	"regexp"
 	"sort"
 	"strconv"
@@ -63,40 +61,6 @@ func zoneFromPath(host string, path string, rec record) (string, int, error) {
 	url := append(pathSlice, host)
 	url = append([]string{basezone}, url...)
 	return strings.Join(url, "."), from, nil
-}
-
-func getFinalRecord(zone string, from int, ctx context.Context, c Config) (record, error) {
-	txts, err := query(zone, ctx, c)
-	if err != nil {
-		return record{}, err
-	}
-
-	// if nothing found, jump into wildcards
-	for i := 1; i <= from && len(txts) == 0; i++ {
-		zoneSlice := strings.Split(zone, ".")
-		zoneSlice[i] = "_"
-		zone = strings.Join(zoneSlice, ".")
-		if c.Resolver != "" {
-			net := customResolver(c)
-			txts, err = net.LookupTXT(ctx, zone)
-		} else {
-			txts, err = net.LookupTXT(zone)
-		}
-	}
-	if err != nil || len(txts) == 0 {
-		return record{}, fmt.Errorf("could not get TXT record: %s", err)
-	}
-
-	rec := record{}
-	if err = rec.Parse(txts[0]); err != nil {
-		return rec, fmt.Errorf("could not parse record: %s", err)
-	}
-
-	if rec.Type == "path" {
-		return rec, fmt.Errorf("chaining path is not currently supported")
-	}
-
-	return rec, nil
 }
 
 func reverse(input []string) {

--- a/path.go
+++ b/path.go
@@ -67,15 +67,13 @@ func zoneFromPath(host string, path string, rec record) (string, int, error) {
 func getFinalRecord(zone string, from int, ctx context.Context, c Config) (record, error) {
 	txts, err := query(zone, ctx, c)
 	if err != nil {
-		return record{}, err
-	}
-
-	// if nothing found, jump into wildcards
-	for i := 1; i <= from && len(txts) == 0; i++ {
-		zoneSlice := strings.Split(zone, ".")
-		zoneSlice[i] = "_"
-		zone = strings.Join(zoneSlice, ".")
-		txts, err = query(zone, ctx, c)
+		// if nothing found, jump into wildcards
+		for i := 1; i <= from && len(txts) == 0; i++ {
+			zoneSlice := strings.Split(zone, ".")
+			zoneSlice[i] = "_"
+			zone = strings.Join(zoneSlice, ".")
+			txts, err = query(zone, ctx, c)
+		}
 	}
 	if err != nil || len(txts) == 0 {
 		return record{}, fmt.Errorf("could not get TXT record: %s", err)

--- a/path.go
+++ b/path.go
@@ -1,6 +1,7 @@
 package txtdirect
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -61,6 +62,35 @@ func zoneFromPath(host string, path string, rec record) (string, int, error) {
 	url := append(pathSlice, host)
 	url = append([]string{basezone}, url...)
 	return strings.Join(url, "."), from, nil
+}
+
+func getFinalRecord(zone string, from int, ctx context.Context, c Config) (record, error) {
+	txts, err := query(zone, ctx, c)
+	if err != nil {
+		return record{}, err
+	}
+
+	// if nothing found, jump into wildcards
+	for i := 1; i <= from && len(txts) == 0; i++ {
+		zoneSlice := strings.Split(zone, ".")
+		zoneSlice[i] = "_"
+		zone = strings.Join(zoneSlice, ".")
+		txts, err = query(zone, ctx, c)
+	}
+	if err != nil || len(txts) == 0 {
+		return record{}, fmt.Errorf("could not get TXT record: %s", err)
+	}
+
+	rec := record{}
+	if err = rec.Parse(txts[0]); err != nil {
+		return rec, fmt.Errorf("could not parse record: %s", err)
+	}
+
+	if rec.Type == "path" {
+		return rec, fmt.Errorf("chaining path is not currently supported")
+	}
+
+	return rec, nil
 }
 
 func reverse(input []string) {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -254,19 +254,16 @@ func query(zone string, ctx context.Context, c Config) ([]string, error) {
 		zone = zoneSlice[0]
 	}
 
-	var newZone string
 	if !strings.HasPrefix(zone, basezone) {
-		newZone = strings.Join([]string{basezone, zone}, ".")
-	} else {
-		newZone = zone
+		zone = strings.Join([]string{basezone, zone}, ".")
 	}
 
 	// Use absolute zone
 	var absoluteZone string
-	if strings.HasSuffix(newZone, ".") {
-		absoluteZone = newZone
+	if strings.HasSuffix(zone, ".") {
+		absoluteZone = zone
 	} else {
-		absoluteZone = strings.Join([]string{newZone, "."}, "")
+		absoluteZone = strings.Join([]string{zone, "."}, "")
 	}
 
 	var txts []string

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -258,7 +258,7 @@ func query(zone string, ctx context.Context, c Config) ([]string, error) {
 	if !strings.HasPrefix(zone, basezone) {
 		newZone = strings.Join([]string{basezone, zone}, ".")
 	} else {
-		newZone = strings.Join([]string{zone, "."}, "")
+		newZone = zone
 	}
 
 	// Use absolute zone

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -343,7 +343,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 			zone, from, err := zoneFromPath(host, path, rec)
 			rec, err = getFinalRecord(zone, from, r.Context(), c)
 			if err != nil {
-				log.Print("Fallback is triggerd because an error has occurred: ", err)
+				log.Print("Fallback is triggered because an error has occurred: ", err)
 				fallback(w, r, fallbackURL, code, c)
 				return err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where port was being used with zone. Also uses query as a global function to remove port from zone and use absolute zone.