### PR TITLE
Proxy requests instead of redirecting

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -33,7 +33,9 @@ const (
 	basezone        = "_redirect"
 	defaultSub      = "www"
 	defaultProtocol = "https"
+	keepalive       = 30
 	logFormat       = "02/Jan/2006:15:04:05 -0700"
+	timeout         = 30 * time.Second
 )
 
 var PlaceholderRegex = regexp.MustCompile("{[~>?]?\\w+}")
@@ -355,7 +357,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		if err != nil {
 			return err
 		}
-		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", 1)
+		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", keepalive, timeout)
 		reverseProxy.ServeHTTP(w, r, nil)
 		return nil
 	}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mholt/caddy/caddyhttp/proxy"
 )
 
 const (
@@ -345,6 +347,17 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 				return err
 			}
 		}
+	}
+
+	if rec.Type == "proxy" {
+		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), rec.From, rec.To)
+		u, err := url.Parse(rec.To)
+		if err != nil {
+			return err
+		}
+		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", 1)
+		reverseProxy.ServeHTTP(w, r, nil)
+		return nil
 	}
 
 	if rec.Type == "host" {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -33,9 +33,9 @@ const (
 	basezone        = "_redirect"
 	defaultSub      = "www"
 	defaultProtocol = "https"
-	keepalive       = 30
+	proxyKeepalive  = 30
 	logFormat       = "02/Jan/2006:15:04:05 -0700"
-	timeout         = 30 * time.Second
+	proxyTimeout    = 30 * time.Second
 )
 
 var PlaceholderRegex = regexp.MustCompile("{[~>?]?\\w+}")
@@ -357,7 +357,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		if err != nil {
 			return err
 		}
-		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", keepalive, timeout)
+		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", proxyKeepalive, proxyTimeout)
 		reverseProxy.ServeHTTP(w, r, nil)
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new proxy type and uses Caddy's reverse proxy functionality in order to perform proxy requests instead of redirecting.

**Which issue this PR fixes**:
PoC for #86 
