### PR TITLE
Add DNS server mocking for query function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 script:
   - go get -u github.com/mholt/caddy
-  - go get -u gopkg.in/natefinch/lumberjack.v2
+  - go get -u github.com/natefinch/lumberjack
   - go get -u github.com/miekg/dns
   - go test -v ./...
   - make travis-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - go get -u github.com/mholt/caddy
   - go get -u github.com/natefinch/lumberjack
   - go get -u github.com/miekg/dns
-  - go test -v ./...
+  - go test -v -race ./...
   - make travis-build
 
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ services:
 
 script:
   - go get -u github.com/mholt/caddy
-  - go get gopkg.in/natefinch/lumberjack.v2
+  - go get -u gopkg.in/natefinch/lumberjack.v2
+  - go get -u github.com/miekg/dns
   - go test -v ./...
   - make travis-build
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ fetch-dependencies:
 	go get github.com/caddyserver/builds
 	go get github.com/miekg/caddy-prometheus
 	go get github.com/captncraig/caddy-realip
-	go get gopkg.in/natefinch/lumberjack.v2
+	go get github.com/natefinch/lumberjack
 	go get github.com/miekg/dns
 	go get -d -u
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ fetch-dependencies:
 	go get github.com/miekg/caddy-prometheus
 	go get github.com/captncraig/caddy-realip
 	go get gopkg.in/natefinch/lumberjack.v2
+	go get github.com/miekg/dns
 	go get -d -u
 
 docker:

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/natefinch/lumberjack"
 
 	"github.com/txtdirect/txtdirect"
-	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func init() {

--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -327,8 +327,8 @@ func Test_query(t *testing.T) {
 			txts["_redirect.pkg.txtdirect."],
 		},
 	}
+	go RunDNSServer()
 	for _, test := range tests {
-		go RunDNSServer()
 		ctx := context.Background()
 		c := Config{
 			Resolver: "127.0.0.1:" + strconv.Itoa(port),
@@ -340,7 +340,6 @@ func Test_query(t *testing.T) {
 		if resp[0] != txts[test.zone] {
 			t.Fatalf("Expected %s, got %s", txts[test.zone], resp[0])
 		}
-		server.Shutdown()
 	}
 }
 
@@ -373,6 +372,7 @@ func handleDNSRequest(w dns.ResponseWriter, r *dns.Msg) {
 func RunDNSServer() {
 	dns.HandleFunc("txtdirect.", handleDNSRequest)
 	err := server.ListenAndServe()
+	defer server.Shutdown()
 	if err != nil {
 		log.Fatalf("Failed to start server: %s\n ", err.Error())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements a local DNS server for e2e tests. For now, it only contains tests for ``query`` function.

**Special notes for your reviewer**:
We need to discuss what else we want to test.
