### PR TITLE
PoC version of docker vanity urls

### DIFF
--- a/dockerv2.go
+++ b/dockerv2.go
@@ -36,7 +36,7 @@ func createDockerv2URI(to string, path string) (string, error) {
 		return "", err
 	}
 
-	if uri.Path == "/" {
+	if uri.Path == "/" || uri.Path == "" {
 		uri.Path = path
 		return uri.String(), nil
 	}

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -16,9 +16,6 @@ var regexs = []string{
 
 func generateDockerv2URI(path string, rec record) (string, error) {
 	uri := rec.To
-	if rec.Re == "" && rec.To == "" {
-		log.Printf("<%s> [txtdirect]: re= and to= fields are required in dockerv2 type.", time.Now().Format(logFormat))
-	}
 	Dockerv2Regex, err := regexp.Compile(rec.Re)
 	if err != nil {
 		log.Printf("<%s> [txtdirect]: the given regex doesn't work as expected: %s", time.Now().Format(logFormat), rec.Re)

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -1,0 +1,40 @@
+package txtdirect
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var regexs = []string{
+	"^/v2/_catalog$",
+	"^/v2/(.*)/tags/(.*)",
+	"^/v2/(.*)/manifests/(.*)",
+}
+
+func generateDockerv2URI(path string, rec record) (string, error) {
+	uri := rec.To
+	if rec.Re == "" && rec.To == "" {
+		log.Printf("<%s> [txtdirect]: re= and to= fields are required in dockerv2 type.", time.Now().Format(logFormat))
+	}
+	Dockerv2Regex, err := regexp.Compile(rec.Re)
+	if err != nil {
+		log.Printf("<%s> [txtdirect]: the given regex doesn't work as expected: %s", time.Now().Format(logFormat), rec.Re)
+	}
+	pathSubmatches := Dockerv2Regex.FindAllStringSubmatch(path, -1)
+	if len(pathSubmatches) < 1 {
+		log.Printf("<%s> [txtdirect]: can't extract submatches from %s, with %s", time.Now().Format(logFormat), path, rec.Re)
+	}
+	pathSlice := pathSubmatches[0][1:]
+
+	for i, v := range pathSlice {
+		uri = strings.Replace(uri, fmt.Sprintf("$%d", i+1), v, -1)
+	}
+	if len(pathSlice) < 1 && rec.Re != "" {
+		log.Printf("<%s> [txtdirect]: dockerv2 regex (%s) doesn't work on %s", time.Now().Format(logFormat), rec.Re, path)
+	}
+
+	return uri, nil
+}

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -28,6 +28,7 @@ func redirectDockerv2(w http.ResponseWriter, r *http.Request, rec record) error 
 		return err
 	}
 	if path != "/" {
+		fmt.Println(path)
 		regexType := DockerRegex.FindAllStringSubmatch(path, -1)[0]
 		pathRegex, err := regexp.Compile(dockerRegexs[regexType[len(regexType)-1]])
 		if err != nil {

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -16,7 +16,7 @@ var dockerRegexs = map[string]string{
 var DockerRegex = regexp.MustCompile("^\\/v2\\/(.*\\/(tags|manifests|blobs)\\/.*|_catalog$)")
 
 func generateDockerv2URI(path string, rec record) (string, int) {
-	if path != "" {
+	if path != "/" {
 		regexType := DockerRegex.FindAllStringSubmatch(path, -1)[0]
 		pathRegex, err := regexp.Compile(dockerRegexs[regexType[len(regexType)-1]])
 		if err != nil {

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -7,37 +7,31 @@ import (
 	"strings"
 )
 
-var dockerRegexs = map[string]string{
-	"v2":        "^\\/?v2\\/?$",
-	"_catalog":  "^/v2/_catalog$",
-	"tags":      "^/v2/(.*)/tags/(.*)",
-	"manifests": "^/v2/(.*)/manifests/(.*)",
-	"blobs":     "^/v2/(.*)/blobs/(.*)",
+var dockerRegexes = map[string]*regexp.Regexp{
+	"v2":        regexp.MustCompile("^\\/?v2\\/?$"),
+	"_catalog":  regexp.MustCompile("^/v2/_catalog$"),
+	"tags":      regexp.MustCompile("^/v2/(.*)/tags/(.*)"),
+	"manifests": regexp.MustCompile("^/v2/(.*)/manifests/(.*)"),
+	"blobs":     regexp.MustCompile("^/v2/(.*)/blobs/(.*)"),
 }
 
 var DockerRegex = regexp.MustCompile("^\\/v2\\/(.*\\/(tags|manifests|blobs)\\/.*|_catalog$)")
 
 func redirectDockerv2(w http.ResponseWriter, r *http.Request, rec record) error {
 	path := r.URL.Path
-	v2Regex, err := regexp.Compile(dockerRegexs["v2"])
-	if err != nil {
-		panic(err)
-	}
-	if v2Regex.MatchString(path) {
+	if dockerRegexes["v2"].MatchString(path) {
 		_, err := w.Write([]byte(http.StatusText(http.StatusOK)))
 		return err
 	}
 	if path != "/" {
-		fmt.Println(path)
 		regexType := DockerRegex.FindAllStringSubmatch(path, -1)[0]
-		pathRegex, err := regexp.Compile(dockerRegexs[regexType[len(regexType)-1]])
-		if err != nil {
-			panic(err)
+		if regexType[len(regexType)-1] == "" {
+			regexType = regexType[:len(regexType)-1]
 		}
-		pathSubmatches := pathRegex.FindAllStringSubmatch(path, -1)
+		pathSubmatches := dockerRegexes[regexType[len(regexType)-1]].FindAllStringSubmatch(path, -1)
 		pathSlice := pathSubmatches[0][1:]
 
-		uri := rec.To
+		uri := rec.To + path
 		for i, v := range pathSlice {
 			uri = strings.Replace(uri, fmt.Sprintf("$%d", i+1), v, -1)
 		}

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -15,6 +15,7 @@ var dockerRegexes = map[string]*regexp.Regexp{
 func redirectDockerv2(w http.ResponseWriter, r *http.Request, rec record) error {
 	path := r.URL.Path
 	if dockerRegexes["v2"].MatchString(path) {
+		w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
 		_, err := w.Write([]byte(http.StatusText(http.StatusOK)))
 		return err
 	}

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -8,12 +8,6 @@ import (
 	"time"
 )
 
-var regexs = []string{
-	"^/v2/_catalog$",
-	"^/v2/(.*)/tags/(.*)",
-	"^/v2/(.*)/manifests/(.*)",
-}
-
 func generateDockerv2URI(path string, rec record) (string, error) {
 	uri := rec.To
 	Dockerv2Regex, err := regexp.Compile(rec.Re)

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -1,31 +1,6 @@
 package txtdirect
 
-import (
-	"fmt"
-	"log"
-	"regexp"
-	"strings"
-	"time"
-)
-
-func generateDockerv2URI(path string, rec record) (string, error) {
-	uri := rec.To
-	Dockerv2Regex, err := regexp.Compile(rec.Re)
-	if err != nil {
-		log.Printf("<%s> [txtdirect]: the given regex doesn't work as expected: %s", time.Now().Format(logFormat), rec.Re)
-	}
-	pathSubmatches := Dockerv2Regex.FindAllStringSubmatch(path, -1)
-	if len(pathSubmatches) < 1 {
-		log.Printf("<%s> [txtdirect]: can't extract submatches from %s, with %s", time.Now().Format(logFormat), path, rec.Re)
-	}
-	pathSlice := pathSubmatches[0][1:]
-
-	for i, v := range pathSlice {
-		uri = strings.Replace(uri, fmt.Sprintf("$%d", i+1), v, -1)
-	}
-	if len(pathSlice) < 1 && rec.Re != "" {
-		log.Printf("<%s> [txtdirect]: dockerv2 regex (%s) doesn't work on %s", time.Now().Format(logFormat), rec.Re, path)
-	}
-
-	return uri, nil
+func generateDockerv2URI(path string, rec record) (string, int) {
+	// TODO: parse path in future to support all docker apis
+	return rec.To, rec.Code
 }

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -8,7 +8,7 @@ import (
 )
 
 var dockerRegexs = map[string]string{
-	"v2":        "/v2/?",
+	"v2":        "^\\/?v2\\/?$",
 	"_catalog":  "^/v2/_catalog$",
 	"tags":      "^/v2/(.*)/tags/(.*)",
 	"manifests": "^/v2/(.*)/manifests/(.*)",
@@ -23,7 +23,7 @@ func redirectDockerv2(w http.ResponseWriter, r *http.Request, rec record) error 
 	if err != nil {
 		panic(err)
 	}
-	if v2Regex.Match([]byte(path)) {
+	if v2Regex.MatchString(path) {
 		_, err := w.Write([]byte(http.StatusText(http.StatusOK)))
 		return err
 	}

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -1,21 +1,16 @@
 package txtdirect
 
 import (
-	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 )
 
 var dockerRegexes = map[string]*regexp.Regexp{
 	"v2":        regexp.MustCompile("^\\/?v2\\/?$"),
-	"_catalog":  regexp.MustCompile("^/v2/_catalog$"),
-	"tags":      regexp.MustCompile("^/v2/(.*)/tags/(.*)"),
-	"manifests": regexp.MustCompile("^/v2/(.*)/manifests/(.*)"),
-	"blobs":     regexp.MustCompile("^/v2/(.*)/blobs/(.*)"),
+	"container": regexp.MustCompile("v2\\/(([\\w\\d-]+\\/?)+)\\/(tags|manifests|_catalog|blobs)"),
 }
-
-var DockerRegex = regexp.MustCompile("^\\/v2\\/(.*\\/(tags|manifests|blobs)\\/.*|_catalog$)")
 
 func redirectDockerv2(w http.ResponseWriter, r *http.Request, rec record) error {
 	path := r.URL.Path
@@ -24,20 +19,39 @@ func redirectDockerv2(w http.ResponseWriter, r *http.Request, rec record) error 
 		return err
 	}
 	if path != "/" {
-		regexType := DockerRegex.FindAllStringSubmatch(path, -1)[0]
-		if regexType[len(regexType)-1] == "" {
-			regexType = regexType[:len(regexType)-1]
-		}
-		pathSubmatches := dockerRegexes[regexType[len(regexType)-1]].FindAllStringSubmatch(path, -1)
-		pathSlice := pathSubmatches[0][1:]
-
-		uri := rec.To + path
-		for i, v := range pathSlice {
-			uri = strings.Replace(uri, fmt.Sprintf("$%d", i+1), v, -1)
+		uri, err := createDockerv2URI(rec.To, path)
+		if err != nil {
+			return err
 		}
 		http.Redirect(w, r, uri, http.StatusMovedPermanently)
 		return nil
 	}
 	http.Redirect(w, r, rec.To, http.StatusMovedPermanently)
 	return nil
+}
+
+func createDockerv2URI(to string, path string) (string, error) {
+	uri, err := url.Parse(to)
+	if err != nil {
+		return "", err
+	}
+
+	if uri.Path == "/" {
+		uri.Path = path
+		return uri.String(), nil
+	}
+
+	// Replace container's path in docker's request with what's inside rec.To
+	containerPath := dockerRegexes["container"].FindAllStringSubmatch(path, -1)[0][1] // [0][1]: The second item in first group is always container path
+	containerAndVersion := strings.Split(uri.Path, ":")                               // First item in slice is container and second item is version
+	uri.Path = strings.Replace(path, containerPath, containerAndVersion[0][1:], -1)
+
+	// Replace the version number in docker's request with what's inside rec.To
+	if len(containerAndVersion) == 2 {
+		pathSlice := strings.Split(uri.Path, "/")
+		pathSlice[len(pathSlice)-1] = containerAndVersion[1]
+		uri.Path = strings.Join(pathSlice, "/")
+	}
+
+	return uri.String(), nil
 }

--- a/dockerv2.go
+++ b/dockerv2.go
@@ -1,6 +1,35 @@
 package txtdirect
 
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var dockerRegexs = map[string]string{
+	"_catalog":  "^/v2/_catalog$",
+	"tags":      "^/v2/(.*)/tags/(.*)",
+	"manifests": "^/v2/(.*)/manifests/(.*)",
+	"blobs":     "^/v2/(.*)/blobs/(.*)",
+}
+
+var DockerRegex = regexp.MustCompile("^\\/v2\\/(.*\\/(tags|manifests|blobs)\\/.*|_catalog$)")
+
 func generateDockerv2URI(path string, rec record) (string, int) {
-	// TODO: parse path in future to support all docker apis
+	if path != "" {
+		regexType := DockerRegex.FindAllStringSubmatch(path, -1)[0]
+		pathRegex, err := regexp.Compile(dockerRegexs[regexType[len(regexType)-1]])
+		if err != nil {
+			panic(err)
+		}
+		pathSubmatches := pathRegex.FindAllStringSubmatch(path, -1)
+		pathSlice := pathSubmatches[0][1:]
+
+		uri := rec.To
+		for i, v := range pathSlice {
+			uri = strings.Replace(uri, fmt.Sprintf("$%d", i+1), v, -1)
+		}
+		return uri, rec.Code
+	}
 	return rec.To, rec.Code
 }

--- a/dockerv2_test.go
+++ b/dockerv2_test.go
@@ -1,0 +1,55 @@
+package txtdirect
+
+import (
+	"testing"
+)
+
+func Test_generateDockerv2URI(t *testing.T) {
+	tests := []struct {
+		path     string
+		rec      record
+		expected string
+	}{
+		{
+			"/v2/testing/tags/docker",
+			record{
+				Re: "^/v2/(.*)/tags/(.*)",
+				To: "https://gcr.io/v2/my_bucket/$1/tags/$2",
+			},
+			"https://gcr.io/v2/my_bucket/testing/tags/docker",
+		},
+		{
+			"/v2/testing/manifests/docker",
+			record{
+				Re: "^/v2/(.*)/manifests/(.*)",
+				To: "https://gcr.io/v2/my_bucket/$1/manifests/$2",
+			},
+			"https://gcr.io/v2/my_bucket/testing/manifests/docker",
+		},
+		{
+			"/v2/testing/blobs/docker",
+			record{
+				Re: "^/v2/(.*)/blobs/(.*)",
+				To: "https://gcr.io/v2/my_bucket/$1/blobs/$2",
+			},
+			"https://gcr.io/v2/my_bucket/testing/blobs/docker",
+		},
+		{
+			"/v2/_catalog",
+			record{
+				Re: "^/v2/_catalog$",
+				To: "https://gcr.io/v2/_catalog",
+			},
+			"https://gcr.io/v2/_catalog",
+		},
+	}
+	for _, test := range tests {
+		uri, err := generateDockerv2URI(test.path, test.rec)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err.Error())
+		}
+		if uri != test.expected {
+			t.Fatalf("Expected %s, got %s", test.expected, uri)
+		}
+	}
+}

--- a/dockerv2_test.go
+++ b/dockerv2_test.go
@@ -11,43 +11,16 @@ func Test_generateDockerv2URI(t *testing.T) {
 		expected string
 	}{
 		{
-			"/v2/testing/tags/docker",
+			"",
 			record{
-				Re: "^/v2/(.*)/tags/(.*)",
-				To: "https://gcr.io/v2/my_bucket/$1/tags/$2",
+				To:   "docker.io/seetheprogress/txtdirect:latest",
+				Code: 302,
 			},
-			"https://gcr.io/v2/my_bucket/testing/tags/docker",
-		},
-		{
-			"/v2/testing/manifests/docker",
-			record{
-				Re: "^/v2/(.*)/manifests/(.*)",
-				To: "https://gcr.io/v2/my_bucket/$1/manifests/$2",
-			},
-			"https://gcr.io/v2/my_bucket/testing/manifests/docker",
-		},
-		{
-			"/v2/testing/blobs/docker",
-			record{
-				Re: "^/v2/(.*)/blobs/(.*)",
-				To: "https://gcr.io/v2/my_bucket/$1/blobs/$2",
-			},
-			"https://gcr.io/v2/my_bucket/testing/blobs/docker",
-		},
-		{
-			"/v2/_catalog",
-			record{
-				Re: "^/v2/_catalog$",
-				To: "https://gcr.io/v2/_catalog",
-			},
-			"https://gcr.io/v2/_catalog",
+			"docker.io/seetheprogress/txtdirect:latest",
 		},
 	}
 	for _, test := range tests {
-		uri, err := generateDockerv2URI(test.path, test.rec)
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err.Error())
-		}
+		uri, _ := generateDockerv2URI(test.path, test.rec)
 		if uri != test.expected {
 			t.Fatalf("Expected %s, got %s", test.expected, uri)
 		}

--- a/dockerv2_test.go
+++ b/dockerv2_test.go
@@ -16,18 +16,10 @@ func Test_generateDockerv2URI(t *testing.T) {
 		{
 			"/v2/",
 			record{
-				To:   "docker.io/seetheprogress/txtdirect:latest",
+				To:   "https://gcr.io/seetheprogress/txtdirect:latest",
 				Code: 302,
 			},
 			"OK",
-		},
-		{
-			"/v2/random/container/tags/latest",
-			record{
-				To:   "https://gcr.io/testing/container",
-				Code: 302,
-			},
-			"https://gcr.io/v2/testing/container/tags/latest",
 		},
 		{
 			"/v2/random/container/tags/latest",
@@ -38,26 +30,53 @@ func Test_generateDockerv2URI(t *testing.T) {
 			"https://gcr.io/v2/random/container/tags/latest",
 		},
 		{
+			"/v2/random/container/tags/v2.0.0",
+			record{
+				To:   "https://gcr.io/",
+				Code: 302,
+			},
+			"https://gcr.io/v2/random/container/tags/v2.0.0",
+		},
+		{
+			"/v2/testing/container/tags/v3.0.0",
+			record{
+				To:   "https://gcr.io/testing/container:v2.0.0",
+				Code: 302,
+			},
+			"https://gcr.io/v2/testing/container/tags/v2.0.0",
+		},
+		{
+			"/v2/testing/container/tags/v2.0.0",
+			record{
+				To:   "https://gcr.io/testing/container",
+				Code: 302,
+			},
+			"https://gcr.io/v2/testing/container/tags/v2.0.0",
+		},
+		{
+			"/v2/random/container/tags/latest",
+			record{
+				To:   "https://gcr.io/testing/container:v2.0.0",
+				Code: 302,
+			},
+			"https://gcr.io/v2/testing/container/tags/v2.0.0",
+		},
+
+		{
+			"/v2/random/container/tags/v2.0.0",
+			record{
+				To:   "https://gcr.io/testing/container",
+				Code: 302,
+			},
+			"https://gcr.io/v2/testing/container/tags/v2.0.0",
+		},
+		{
 			"/v2/random/container/_catalog",
 			record{
 				To:   "https://gcr.io/",
 				Code: 302,
 			},
 			"https://gcr.io/v2/random/container/_catalog",
-		},
-		{
-			"/v2/random/container/manifests/v3.0.0",
-			record{
-				To: "https://gcr.io/testing/container",
-			},
-			"https://gcr.io/v2/testing/container/manifests/v3.0.0",
-		},
-		{
-			"/v2/random/container/manifests/v3.0.0",
-			record{
-				To: "https://gcr.io/testing/container:v2.0.0",
-			},
-			"https://gcr.io/v2/testing/container/manifests/v2.0.0",
 		},
 	}
 	for _, test := range tests {

--- a/dockerv2_test.go
+++ b/dockerv2_test.go
@@ -22,33 +22,42 @@ func Test_generateDockerv2URI(t *testing.T) {
 			"OK",
 		},
 		{
-			"/v2/testing/tags/docker",
+			"/v2/random/container/tags/latest",
 			record{
-				To:   "https://gcr.io/v2/my_bucket/$1/tags/$2",
+				To:   "https://gcr.io/testing/container",
 				Code: 302,
 			},
-			"https://gcr.io/v2/my_bucket/testing/tags/docker",
+			"https://gcr.io/v2/testing/container/tags/latest",
 		},
 		{
-			"/v2/testing/manifests/docker",
+			"/v2/random/container/tags/latest",
 			record{
-				To: "https://gcr.io/v2/my_bucket/$1/manifests/$2",
+				To:   "https://gcr.io/",
+				Code: 302,
 			},
-			"https://gcr.io/v2/my_bucket/testing/manifests/docker",
+			"https://gcr.io/v2/random/container/tags/latest",
 		},
 		{
-			"/v2/testing/blobs/docker",
+			"/v2/random/container/_catalog",
 			record{
-				To: "https://gcr.io/v2/my_bucket/$1/blobs/$2",
+				To:   "https://gcr.io/",
+				Code: 302,
 			},
-			"https://gcr.io/v2/my_bucket/testing/blobs/docker",
+			"https://gcr.io/v2/random/container/_catalog",
 		},
 		{
-			"/v2/_catalog",
+			"/v2/random/container/manifests/v3.0.0",
 			record{
-				To: "https://gcr.io/v2/_catalog",
+				To: "https://gcr.io/testing/container",
 			},
-			"https://gcr.io/v2/_catalog",
+			"https://gcr.io/v2/testing/container/manifests/v3.0.0",
+		},
+		{
+			"/v2/random/container/manifests/v3.0.0",
+			record{
+				To: "https://gcr.io/testing/container:v2.0.0",
+			},
+			"https://gcr.io/v2/testing/container/manifests/v2.0.0",
 		},
 	}
 	for _, test := range tests {

--- a/dockerv2_test.go
+++ b/dockerv2_test.go
@@ -18,6 +18,35 @@ func Test_generateDockerv2URI(t *testing.T) {
 			},
 			"docker.io/seetheprogress/txtdirect:latest",
 		},
+		{
+			"/v2/testing/tags/docker",
+			record{
+				To:   "https://gcr.io/v2/my_bucket/$1/tags/$2",
+				Code: 302,
+			},
+			"https://gcr.io/v2/my_bucket/testing/tags/docker",
+		},
+		{
+			"/v2/testing/manifests/docker",
+			record{
+				To: "https://gcr.io/v2/my_bucket/$1/manifests/$2",
+			},
+			"https://gcr.io/v2/my_bucket/testing/manifests/docker",
+		},
+		{
+			"/v2/testing/blobs/docker",
+			record{
+				To: "https://gcr.io/v2/my_bucket/$1/blobs/$2",
+			},
+			"https://gcr.io/v2/my_bucket/testing/blobs/docker",
+		},
+		{
+			"/v2/_catalog",
+			record{
+				To: "https://gcr.io/v2/_catalog",
+			},
+			"https://gcr.io/v2/_catalog",
+		},
 	}
 	for _, test := range tests {
 		uri, _ := generateDockerv2URI(test.path, test.rec)

--- a/dockerv2_test.go
+++ b/dockerv2_test.go
@@ -1,6 +1,9 @@
 package txtdirect
 
 import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -11,12 +14,12 @@ func Test_generateDockerv2URI(t *testing.T) {
 		expected string
 	}{
 		{
-			"",
+			"/v2/",
 			record{
 				To:   "docker.io/seetheprogress/txtdirect:latest",
 				Code: 302,
 			},
-			"docker.io/seetheprogress/txtdirect:latest",
+			"OK",
 		},
 		{
 			"/v2/testing/tags/docker",
@@ -49,9 +52,14 @@ func Test_generateDockerv2URI(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		uri, _ := generateDockerv2URI(test.path, test.rec)
-		if uri != test.expected {
-			t.Fatalf("Expected %s, got %s", test.expected, uri)
+		req := httptest.NewRequest("GET", fmt.Sprintf("https://example.com%s", test.path), nil)
+		resp := httptest.NewRecorder()
+		err := redirectDockerv2(resp, req, test.rec)
+		if err != nil {
+			t.Errorf("Unexpected error happened: %s", err)
+		}
+		if !strings.Contains(resp.Body.String(), test.expected) {
+			t.Errorf("Expected %s, got %s:", test.expected, resp.Body.String())
 		}
 	}
 }

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -34,6 +34,7 @@ const (
 	defaultSub      = "www"
 	defaultProtocol = "https"
 	proxyKeepalive  = 30
+	fallbackDelay   = 300 * time.Millisecond
 	logFormat       = "02/Jan/2006:15:04:05 -0700"
 	proxyTimeout    = 30 * time.Second
 )
@@ -360,7 +361,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		if err != nil {
 			return err
 		}
-		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", proxyKeepalive, proxyTimeout)
+		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", proxyKeepalive, proxyTimeout, fallbackDelay)
 		reverseProxy.ServeHTTP(w, r, nil)
 		return nil
 	}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -112,7 +112,7 @@ func (r *record) Parse(str string) error {
 		if len(l) > 255 {
 			return fmt.Errorf("TXT record cannot exceed the maximum of 255 characters")
 		}
-		if r.To == "dockerv2" && r.Re == "" && r.To == "" {
+		if r.Type == "dockerv2" && r.Re == "" && r.To == "" {
 			return fmt.Errorf("<%s> [txtdirect]: re= and to= fields are required in dockerv2 type", time.Now().Format(logFormat))
 		}
 	}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -366,8 +366,10 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	}
 
 	if rec.Type == "dockerv2" {
-		uri, code := generateDockerv2URI(path, rec)
-		http.Redirect(w, r, uri, code)
+		err := redirectDockerv2(w, r, rec)
+		if err != nil {
+			panic(err)
+		}
 		return nil
 	}
 

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -112,6 +112,9 @@ func (r *record) Parse(str string) error {
 		if len(l) > 255 {
 			return fmt.Errorf("TXT record cannot exceed the maximum of 255 characters")
 		}
+		if r.To == "dockerv2" && r.Re == "" && r.To == "" {
+			return fmt.Errorf("<%s> [txtdirect]: re= and to= fields are required in dockerv2 type", time.Now().Format(logFormat))
+		}
 	}
 
 	if r.Code == 0 {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -112,8 +112,8 @@ func (r *record) Parse(str string) error {
 		if len(l) > 255 {
 			return fmt.Errorf("TXT record cannot exceed the maximum of 255 characters")
 		}
-		if r.Type == "dockerv2" && r.Re == "" && r.To == "" {
-			return fmt.Errorf("<%s> [txtdirect]: re= and to= fields are required in dockerv2 type", time.Now().Format(logFormat))
+		if r.Type == "dockerv2" && r.To == "" {
+			return fmt.Errorf("<%s> [txtdirect]: to= field is required in dockerv2 type", time.Now().Format(logFormat))
 		}
 	}
 
@@ -366,11 +366,8 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	}
 
 	if rec.Type == "dockerv2" {
-		uri, err := generateDockerv2URI(path, rec)
-		if err != nil {
-			return err
-		}
-		http.Redirect(w, r, uri, 302)
+		uri, code := generateDockerv2URI(path, rec)
+		http.Redirect(w, r, uri, code)
 		return nil
 	}
 

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -362,6 +362,15 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		return nil
 	}
 
+	if rec.Type == "dockerv2" {
+		uri, err := generateDockerv2URI(path, rec)
+		if err != nil {
+			return err
+		}
+		http.Redirect(w, r, uri, 302)
+		return nil
+	}
+
 	if rec.Type == "host" {
 		to, code := getBaseTarget(rec, r)
 		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), to)


### PR DESCRIPTION
**What this PR does / why we need it**:
It defines a new type called ``dockerv2`` that handles docker vanity URLs redirection.

**Which issue this PR fixes**:
fixes #14 


**Special notes for your reviewer**:
It's jsut a PoC version and needs more work and discussion.
