### PR TITLE
Advanced version for proxy requests

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -40,7 +40,7 @@ func parse(c *caddy.Controller) (txtdirect.Config, error) {
 	var enable []string
 	var redirect string
 	var resolver string
-	reverseProxy := proxy.Proxy{}
+	var reverseProxy proxy.Proxy
 
 	c.Next() // skip directive name
 	for c.NextBlock() {
@@ -80,16 +80,15 @@ func parse(c *caddy.Controller) (txtdirect.Config, error) {
 			resolver = resolverAddr[0]
 
 		case "proxy":
-			proxyAddr := c.RemainingArgs()
-			if len(proxyAddr) != 1 {
+			toProxy := c.RemainingArgs()
+			if len(toProxy) != 1 {
 				return txtdirect.Config{}, c.ArgErr()
 			}
-			upstreams, err := proxy.NewStaticUpstreams(c.Dispenser, proxyAddr[0])
+			upstreams, err := proxy.NewStaticUpstreams(c.Dispenser, toProxy[0])
 			if err != nil {
 				return txtdirect.Config{}, err
 			}
 			reverseProxy.Upstreams = upstreams
-
 		case "logfile":
 			logfile := c.RemainingArgs()
 			if len(logfile) != 1 {

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -18,6 +18,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
+
+	"github.com/mholt/caddy/caddyfile"
 
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
@@ -80,11 +83,12 @@ func parse(c *caddy.Controller) (txtdirect.Config, error) {
 			resolver = resolverAddr[0]
 
 		case "proxy":
-			toProxy := c.RemainingArgs()
-			if len(toProxy) != 1 {
+			proxyArgs := c.RemainingArgs()
+			if len(proxyArgs) == 0 {
 				return txtdirect.Config{}, c.ArgErr()
 			}
-			upstreams, err := proxy.NewStaticUpstreams(c.Dispenser, toProxy[0])
+			upstreams, err := proxy.NewStaticUpstreams(caddyfile.NewDispenser("caddy.test", strings.NewReader(`
+			proxy / google.com`)), "")
 			if err != nil {
 				return txtdirect.Config{}, err
 			}

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -18,9 +18,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
-
-	"github.com/mholt/caddy/caddyfile"
 
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
@@ -87,12 +84,14 @@ func parse(c *caddy.Controller) (txtdirect.Config, error) {
 			if len(proxyArgs) == 0 {
 				return txtdirect.Config{}, c.ArgErr()
 			}
-			upstreams, err := proxy.NewStaticUpstreams(caddyfile.NewDispenser("caddy.test", strings.NewReader(`
-			proxy / google.com`)), "")
-			if err != nil {
-				return txtdirect.Config{}, err
+			upstreams := reverseProxy.Upstreams
+			for _, host := range proxyArgs {
+				newUpstreams, err := proxy.NewStaticUpstreams(c.Dispenser, host)
+				if err != nil {
+					return txtdirect.Config{}, err
+				}
+				upstreams = append(upstreams, newUpstreams...)
 			}
-			reverseProxy.Upstreams = upstreams
 		case "logfile":
 			logfile := c.RemainingArgs()
 			if len(logfile) != 1 {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -352,7 +352,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		}
 	}
 
-	if rec.Type == "proxy" {
+	if rec.Type == "proxy" && rec.To != "" {
 		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), rec.From, rec.To)
 		u, err := url.Parse(rec.To)
 		if err != nil {
@@ -360,6 +360,14 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		}
 		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", proxyKeepalive, proxyTimeout)
 		reverseProxy.ServeHTTP(w, r, nil)
+		return nil
+	}
+
+	if rec.Type == "proxy" && rec.To == "" {
+		to, _ := getBaseTarget(rec, r)
+		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), to)
+		proxy := c.Proxy
+		proxy.ServeHTTP(w, r)
 		return nil
 	}
 

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -56,6 +56,7 @@ type Config struct {
 	Enable   []string
 	Redirect string
 	Resolver string
+	Proxy    proxy.Proxy
 }
 
 func (r *record) Parse(str string) error {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -33,8 +33,8 @@ const (
 	basezone        = "_redirect"
 	defaultSub      = "www"
 	defaultProtocol = "https"
-	proxyKeepalive  = 30
 	logFormat       = "02/Jan/2006:15:04:05 -0700"
+	proxyKeepalive  = 30
 	proxyTimeout    = 30 * time.Second
 )
 

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -364,10 +364,15 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	}
 
 	if rec.Type == "proxy" && rec.To == "" {
-		to, _ := getBaseTarget(rec, r)
+		to, code := getBaseTarget(rec, r)
 		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), to)
 		proxy := c.Proxy
 		proxy.ServeHTTP(w, r)
+		if err != nil {
+			log.Print("Fallback is triggered because an error has occurred: ", err)
+			fallback(w, r, fallbackURL, code, c)
+			return err
+		}
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows for more advanced proxy request configuration such as configuring multiple upstreams and adding headers to the request.

**Which issue this PR fixes**:
Extends #86 

