### PR TITLE
Disable proxy requests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 script:
   - go get -u github.com/mholt/caddy
-  - go get -u github.com/natefinch/lumberjack
+  - go get -u gopkg.in/natefinch/lumberjack.v2
   - go get -u github.com/miekg/dns
   - go test -v -race ./...
   - make travis-build

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ fetch-dependencies:
 	go get github.com/caddyserver/builds
 	go get github.com/miekg/caddy-prometheus
 	go get github.com/captncraig/caddy-realip
-	go get github.com/natefinch/lumberjack
+	go get gopkg.in/natefinch/lumberjack.v2
 	go get github.com/miekg/dns
 	go get -d -u
 

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -19,9 +19,10 @@ import (
 	"net/http"
 	"os"
 
+	"gopkg.in/natefinch/lumberjack.v2"
+
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
-	"github.com/natefinch/lumberjack"
 
 	"github.com/txtdirect/txtdirect"
 )

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -351,7 +351,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		}
 	}
 
-	if rec.Type == "proxy" {
+	if rec.Type == "proxy" && contains(c.Enable, rec.Type) {
 		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), rec.From, rec.To)
 		u, err := url.Parse(rec.To)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks for the proxy type in c.Enable and does not run a proxy request if the proxy type is not present. Since proxy requests are currently an experimental feature, they are now disabled by default.

**Which issue this PR fixes**:
fixes #107 