### PR TITLE
Add support for placeholders in proxy requests

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -291,7 +291,8 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 
 	if rec.Type == "proxy" {
 		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), rec.From, rec.To)
-		u, err := url.Parse(rec.To)
+		to, _ := getBaseTarget(rec, r)
+		u, err := url.Parse(to)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Proxying currently uses rec.To without checking for placeholders in txt records. This change uses the getBaseTarget function in order to check for placeholders and then parse them before doing proxy requests.

**Which issue this PR fixes**:
fixes #106 
