### PR TITLE
Adds feature gates for all types via config

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -267,7 +267,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		fallback(w, r, fallbackURL, code, c)
 	}
 
-	if rec.Type == "path" {
+	if rec.Type == "path" && contains(c.Enable, rec.Type) {
 		if path == "/" {
 			if rec.Root == "" {
 				fallback(w, r, fallbackURL, code, c)
@@ -289,7 +289,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		}
 	}
 
-	if rec.Type == "proxy" {
+	if rec.Type == "proxy" && contains(c.Enable, rec.Type) {
 		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), rec.From, rec.To)
 		u, err := url.Parse(rec.To)
 		if err != nil {
@@ -300,14 +300,14 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		return nil
 	}
 
-	if rec.Type == "host" {
+	if rec.Type == "host" && contains(c.Enable, rec.Type) {
 		to, code := getBaseTarget(rec, r)
 		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), to)
 		http.Redirect(w, r, to, code)
 		return nil
 	}
 
-	if rec.Type == "gometa" {
+	if rec.Type == "gometa" && contains(c.Enable, rec.Type) {
 		return gometa(w, rec, host, path)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, only www and fallback check the config to see if they should be active before executing. By adding checks for the other record types, they will now be gated if they are not enabled in the config.

**Which issue this PR fixes**:
fixes #110 
