### PR TITLE
Fix race condition in e2e tests

### DIFF
--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -33,7 +33,7 @@ var txts = map[string]string{
 	// type=host
 	"_redirect.e2e.txtdirect.":       "v=txtv0;to=https://e2e.txtdirect.org;type=host",
 	"_redirect.test.path.txtdirect.": "v=txtv0;to=https://path.e2e.txtdirect.org;type=host",
-	// type=pat
+	// type=path
 	"_redirect.path.txtdirect.": "v=txtv0;type=path",
 	// type=""
 	"_redirect.about.txtdirect.": "v=txtv0;to=https://about.txtdirect.org",


### PR DESCRIPTION
**What this PR does / why we need it**:
Creates a channel for the DNS server to kill the go routine when the test is finished.
<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
