### PR TITLE
Add parsing for {labelN} placeholder

### DIFF
--- a/placeholders.go
+++ b/placeholders.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 )
 
@@ -25,6 +26,17 @@ func parsePlaceholders(input string, r *http.Request) string {
 			input = strings.Replace(input, "{host}", r.URL.Host, -1)
 		case "{hostonly}":
 			input = strings.Replace(input, "{hostonly}", r.URL.Hostname(), -1)
+		case "{label":
+			nStr := placeholder[0][6 : len(placeholder[0])-1] // get the integer N in "{labelN}"
+			n, err := strconv.Atoi(nStr)
+			if err != nil || n < 1 {
+				input = strings.Replace(input, placeholder[0], "", -1)
+			}
+			labels := strings.Split(r.Host, ".")
+			if n > len(labels) {
+				input = strings.Replace(input, placeholder[0], "", -1)
+			}
+			input = strings.Replace(input, placeholder[0], labels[n-1], -1)
 		case "{method}":
 			input = strings.Replace(input, "{method}", r.Method, -1)
 		case "{path}":

--- a/placeholders.go
+++ b/placeholders.go
@@ -1,6 +1,7 @@
 package txtdirect
 
 import (
+	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -51,10 +52,16 @@ func parsePlaceholders(input string, r *http.Request) string {
 			nStr := placeholder[0][6 : len(placeholder[0])-1] // get the integer N in "{labelN}"
 			n, err := strconv.Atoi(nStr)
 			if err != nil || n < 1 {
+				if err == nil {
+					log.Print("{label0} is not supported")
+				} else {
+					log.Print(err)
+				}
 				input = strings.Replace(input, placeholder[0], "", -1)
 			}
 			labels := strings.Split(r.URL.Hostname(), ".")
 			if n > len(labels) {
+				log.Printf("Cannot parse a label greater than %d", len(labels))
 				input = strings.Replace(input, placeholder[0], "", -1)
 			}
 			input = strings.Replace(input, placeholder[0], labels[n-1], -1)

--- a/placeholders.go
+++ b/placeholders.go
@@ -48,17 +48,17 @@ func parsePlaceholders(input string, r *http.Request) string {
 			}
 			input = strings.Replace(input, "{user}", user, -1)
 		}
-		/* For multi-level tlds such as example.co.uk, "co" is treated as 
+		/* For multi-level tlds such as example.co.uk, "co" is treated as
 		a subzone from a DNS perspective and would be used as {label1} */
 		if strings.HasPrefix(placeholder[0], "{label") {
 			nStr := placeholder[0][6 : len(placeholder[0])-1] // get the integer N in "{labelN}"
 			n, err := strconv.Atoi(nStr)
-			if err != nil || n < 1 {
-				if err == nil {
-					log.Print("{label0} is not supported")
-				} else {
-					log.Print(err)
-				}
+			if err != nil {
+				log.Print(err)
+				input = strings.Replace(input, placeholder[0], "", -1)
+			}
+			if n < 1 {
+				log.Print("{label0} is not supported")
 				input = strings.Replace(input, placeholder[0], "", -1)
 			}
 			labels := strings.Split(r.URL.Hostname(), ".")

--- a/placeholders.go
+++ b/placeholders.go
@@ -26,17 +26,6 @@ func parsePlaceholders(input string, r *http.Request) string {
 			input = strings.Replace(input, "{host}", r.URL.Host, -1)
 		case "{hostonly}":
 			input = strings.Replace(input, "{hostonly}", r.URL.Hostname(), -1)
-		case "{label":
-			nStr := placeholder[0][6 : len(placeholder[0])-1] // get the integer N in "{labelN}"
-			n, err := strconv.Atoi(nStr)
-			if err != nil || n < 1 {
-				input = strings.Replace(input, placeholder[0], "", -1)
-			}
-			labels := strings.Split(r.Host, ".")
-			if n > len(labels) {
-				input = strings.Replace(input, placeholder[0], "", -1)
-			}
-			input = strings.Replace(input, placeholder[0], labels[n-1], -1)
 		case "{method}":
 			input = strings.Replace(input, "{method}", r.Method, -1)
 		case "{path}":
@@ -57,6 +46,18 @@ func parsePlaceholders(input string, r *http.Request) string {
 				input = strings.Replace(input, "{user}", "", -1)
 			}
 			input = strings.Replace(input, "{user}", user, -1)
+		}
+		if strings.HasPrefix(placeholder[0], "{label") {
+			nStr := placeholder[0][6 : len(placeholder[0])-1] // get the integer N in "{labelN}"
+			n, err := strconv.Atoi(nStr)
+			if err != nil || n < 1 {
+				input = strings.Replace(input, placeholder[0], "", -1)
+			}
+			labels := strings.Split(r.Host, ".")
+			if n > len(labels) {
+				input = strings.Replace(input, placeholder[0], "", -1)
+			}
+			input = strings.Replace(input, placeholder[0], labels[n-1], -1)
 		}
 		if placeholder[0][1] == '>' {
 			want := placeholder[0][2 : len(placeholder[0])-1]

--- a/placeholders.go
+++ b/placeholders.go
@@ -48,6 +48,8 @@ func parsePlaceholders(input string, r *http.Request) string {
 			}
 			input = strings.Replace(input, "{user}", user, -1)
 		}
+		/* For multi-level tlds such as example.co.uk, "co" is treated as 
+		a subzone from a DNS perspective and would be used as {label1} */
 		if strings.HasPrefix(placeholder[0], "{label") {
 			nStr := placeholder[0][6 : len(placeholder[0])-1] // get the integer N in "{labelN}"
 			n, err := strconv.Atoi(nStr)

--- a/placeholders.go
+++ b/placeholders.go
@@ -53,7 +53,7 @@ func parsePlaceholders(input string, r *http.Request) string {
 			if err != nil || n < 1 {
 				input = strings.Replace(input, placeholder[0], "", -1)
 			}
-			labels := strings.Split(r.Host, ".")
+			labels := strings.Split(r.URL.Hostname(), ".")
 			if n > len(labels) {
 				input = strings.Replace(input, placeholder[0], "", -1)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for parsing {labelN} placeholders since that feature is not currently supported.

**Which issue this PR fixes**:
fixes #104