### PR TITLE
Refactor parsePlaceholders when errors occur

### DIFF
--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -348,7 +348,10 @@ func TestParsePlaceholders(t *testing.T) {
 		req := httptest.NewRequest("GET", "https://example.com"+test.placeholder, nil)
 		req.AddCookie(&http.Cookie{Name: "test", Value: "test"})
 		req.Header.Add("Test", "test-header")
-		result := parsePlaceholders(test.url, req)
+		result, err := parsePlaceholders(test.url, req)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if result != test.expected {
 			t.Errorf("Expected %s, got %s", test.expected, result)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactors parsePlaceholders so that it returns errors and triggers fallback when placeholder parsing fails.