### PR TITLE
Move gometa record defaults to gometa.go

### DIFF
--- a/gometa.go
+++ b/gometa.go
@@ -15,9 +15,9 @@ package txtdirect
 
 import (
 	"fmt"
-	"strings"
 	"html/template"
 	"net/http"
+	"strings"
 )
 
 var tmpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
@@ -28,6 +28,9 @@ var tmpl = template.Must(template.New("").Parse(`<!DOCTYPE html>
 </html>`))
 
 func gometa(w http.ResponseWriter, r record, host, path string) error {
+	if r.Vcs == "" {
+		r.Vcs = "git"
+	}
 	if path == "/" {
 		path = ""
 	}

--- a/gometa_test.go
+++ b/gometa_test.go
@@ -47,7 +47,7 @@ func TestGometa(t *testing.T) {
 			expected: `<!DOCTYPE html>
 <html>
 <head>
-<meta name="go-import" content="empty.com/test  ">
+<meta name="go-import" content="empty.com/test git ">
 </head>
 </html>`,
 		},

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -125,10 +125,6 @@ func (r *record) Parse(str string, req *http.Request) error {
 		r.Code = 301
 	}
 
-	if r.Vcs == "" && r.Type == "gometa" {
-		r.Vcs = "git"
-	}
-
 	if r.Type == "" {
 		r.Type = "host"
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Move gometa record defaults to gometa.go

**Which issue this PR fixes**:
fixes #77 

