### PR TITLE
Remove {fragment} placeholder support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -70,7 +70,6 @@ txtdirect {
 # Placeholders
 {dir} 	        The directory of the requested file (from request URI)  
 {file} 	        The name of the requested file (from request URI)  
-{fragment} 	    The last part of the URL starting with "#"  
 {>Header} 	    Any request header, where "Header" is the header field name  
 {host} 	        The host value on the request  
 {hostname} 	    The name of the host machine that is processing the request  
@@ -84,7 +83,7 @@ txtdirect {
 {?key} 	        The value of the "key" argument from the query string  
 {remote} 	      The client's IP address  
 {scheme} 	      The protocol/scheme used (usually http or https)  
-{uri} 	        The request URI (includes path, query string, and fragment)  
+{uri} 	        The request URI (includes path and query string)  
 {uri_escaped} 	The query-escaped variant of {uri}  
 -->
 

--- a/placeholders.go
+++ b/placeholders.go
@@ -23,8 +23,6 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 		case "{file}":
 			_, file := path.Split(r.URL.Path)
 			input = strings.Replace(input, "{file}", file, -1)
-		case "{fragment}":
-			input = strings.Replace(input, "{fragment}", r.URL.Fragment, -1)
 		case "{host}":
 			input = strings.Replace(input, "{host}", r.URL.Host, -1)
 		case "{hostonly}":


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes {fragment} placeholder support since it shouldn't be sent to the server and is not something the server supports. Also removes references to fragment in the README.