### PR TITLE
Add fallbackDelay argument to NewSingleHostReverseProxy function call

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -33,6 +33,7 @@ const (
 	defaultSub      = "www"
 	defaultProtocol = "https"
 	proxyKeepalive  = 30
+	fallbackDelay   = 300 * time.Millisecond
 	logFormat       = "02/Jan/2006:15:04:05 -0700"
 	proxyTimeout    = 30 * time.Second
 )
@@ -335,7 +336,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		if err != nil {
 			return err
 		}
-		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", proxyKeepalive, proxyTimeout)
+		reverseProxy := proxy.NewSingleHostReverseProxy(u, "", proxyKeepalive, proxyTimeout, fallbackDelay)
 		reverseProxy.ServeHTTP(w, r, nil)
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to a change in the caddy NewSingleHostReverseProxy function, a fallbackDelay argument is now required when calling that function.

**Which issue this PR fixes**:
fixes #137 
