### PR TITLE
Add a query for _redirect._ if _redirect isn't found

### DIFF
--- a/placeholders.go
+++ b/placeholders.go
@@ -26,9 +26,9 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 		case "{fragment}":
 			input = strings.Replace(input, "{fragment}", r.URL.Fragment, -1)
 		case "{host}":
-			input = strings.Replace(input, "{host}", r.URL.Host, -1)
+			input = strings.Replace(input, "{host}", r.Host, -1)
 		case "{hostonly}":
-			input = strings.Replace(input, "{hostonly}", r.URL.Hostname(), -1)
+			input = strings.Replace(input, "{hostonly}", r.Host, -1)
 		case "{method}":
 			input = strings.Replace(input, "{method}", r.Method, -1)
 		case "{path}":
@@ -51,7 +51,7 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 			input = strings.Replace(input, "{user}", user, -1)
 		}
 		/* For multi-level tlds such as "example.co.uk", "co" would be used as {label2},
-		 "example" would be {label1} and "uk" would be {label3} */
+		"example" would be {label1} and "uk" would be {label3} */
 		if strings.HasPrefix(placeholder[0], "{label") {
 			nStr := placeholder[0][6 : len(placeholder[0])-1] // get the integer N in "{labelN}"
 			n, err := strconv.Atoi(nStr)
@@ -61,7 +61,7 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 			if n < 1 {
 				return "", fmt.Errorf("{label0} is not supported")
 			}
-			labels := strings.Split(r.URL.Hostname(), ".")
+			labels := strings.Split(r.Host, ".")
 			if n > len(labels) {
 				return "", fmt.Errorf("Cannot parse a label greater than %d", len(labels))
 			}

--- a/placeholders.go
+++ b/placeholders.go
@@ -1,7 +1,6 @@
 package txtdirect
 
 import (
-	"net"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -30,9 +29,10 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 			input = strings.Replace(input, "{host}", r.Host, -1)
 		case "{hostonly}":
 			// Removes port from host
-			host, _, err := net.SplitHostPort(r.Host)
-			if err != nil {
-				return "", err
+			var host string
+			if strings.Contains(r.Host, ":") {
+				hostSlice := strings.Split(r.Host, ":")
+				host = hostSlice[0]
 			}
 			input = strings.Replace(input, "{hostonly}", host, -1)
 		case "{method}":
@@ -68,9 +68,10 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 				return "", fmt.Errorf("{label0} is not supported")
 			}
 			// Removes port from host
-			host, _, err := net.SplitHostPort(r.Host)
-			if err != nil {
-				return "", err
+			var host string
+			if strings.Contains(r.Host, ":") {
+				hostSlice := strings.Split(r.Host, ":")
+				host = hostSlice[0]
 			}
 			labels := strings.Split(host, ".")
 			if n > len(labels) {

--- a/placeholders.go
+++ b/placeholders.go
@@ -29,7 +29,7 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 			input = strings.Replace(input, "{host}", r.Host, -1)
 		case "{hostonly}":
 			// Removes port from host
-			var host string
+			host := r.Host
 			if strings.Contains(r.Host, ":") {
 				hostSlice := strings.Split(r.Host, ":")
 				host = hostSlice[0]
@@ -68,7 +68,7 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 				return "", fmt.Errorf("{label0} is not supported")
 			}
 			// Removes port from host
-			var host string
+			host := r.Host
 			if strings.Contains(r.Host, ":") {
 				hostSlice := strings.Split(r.Host, ":")
 				host = hostSlice[0]

--- a/placeholders.go
+++ b/placeholders.go
@@ -1,6 +1,7 @@
 package txtdirect
 
 import (
+	"net"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -29,10 +30,9 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 			input = strings.Replace(input, "{host}", r.Host, -1)
 		case "{hostonly}":
 			// Removes port from host
-			var host string
-			if strings.Contains(r.Host, ":") {
-				hostSlice := strings.Split(r.Host, ":")
-				host = hostSlice[0]
+			host, _, err := net.SplitHostPort(r.Host)
+			if err != nil {
+				return "", err
 			}
 			input = strings.Replace(input, "{hostonly}", host, -1)
 		case "{method}":
@@ -68,10 +68,9 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 				return "", fmt.Errorf("{label0} is not supported")
 			}
 			// Removes port from host
-			var host string
-			if strings.Contains(r.Host, ":") {
-				hostSlice := strings.Split(r.Host, ":")
-				host = hostSlice[0]
+			host, _, err := net.SplitHostPort(r.Host)
+			if err != nil {
+				return "", err
 			}
 			labels := strings.Split(host, ".")
 			if n > len(labels) {

--- a/placeholders.go
+++ b/placeholders.go
@@ -28,7 +28,13 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 		case "{host}":
 			input = strings.Replace(input, "{host}", r.Host, -1)
 		case "{hostonly}":
-			input = strings.Replace(input, "{hostonly}", r.Host, -1)
+			// Removes port from host
+			var host string
+			if strings.Contains(r.Host, ":") {
+				hostSlice := strings.Split(r.Host, ":")
+				host = hostSlice[0]
+			}
+			input = strings.Replace(input, "{hostonly}", host, -1)
 		case "{method}":
 			input = strings.Replace(input, "{method}", r.Method, -1)
 		case "{path}":
@@ -61,7 +67,13 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 			if n < 1 {
 				return "", fmt.Errorf("{label0} is not supported")
 			}
-			labels := strings.Split(r.Host, ".")
+			// Removes port from host
+			var host string
+			if strings.Contains(r.Host, ":") {
+				hostSlice := strings.Split(r.Host, ":")
+				host = hostSlice[0]
+			}
+			labels := strings.Split(host, ".")
 			if n > len(labels) {
 				return "", fmt.Errorf("Cannot parse a label greater than %d", len(labels))
 			}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -235,7 +235,7 @@ func customResolver(c Config) net.Resolver {
 	}
 }
 
-// query checkes the given zone using net.LookupTXT to
+// query checks the given zone using net.LookupTXT to
 // find TXT records in that zone
 func query(zone string, ctx context.Context, c Config) ([]string, error) {
 	// Removes port from zone

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -231,10 +231,8 @@ func customResolver(c Config) net.Resolver {
 // query checks the given zone using net.LookupTXT to
 // find TXT records in that zone
 func query(zone string, ctx context.Context, c Config) ([]string, error) {
-	// Removes port from zone
-	zone, _, err := net.SplitHostPort(zone)
-	if err != nil {
-		return nil, err
+	if strings.Contains(zone, ":") {
+		return nil, fmt.Errorf("zone should not have a port: %s", zone)
 	}
 
 	if !strings.HasPrefix(zone, basezone) {
@@ -250,6 +248,7 @@ func query(zone string, ctx context.Context, c Config) ([]string, error) {
 	}
 
 	var txts []string
+	var err error
 	if c.Resolver != "" {
 		net := customResolver(c)
 		txts, err = net.LookupTXT(ctx, absoluteZone)

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -165,11 +165,11 @@ func contains(array []string, word string) bool {
 	return false
 }
 
-// getRecord uses the given host and path to find a TXT record
+// getRecord uses the given host to find a TXT record
 // and then parses the txt record and returns a TXTDirect record
-// struct instance It returns an error when it can't find any txt
+// struct instance. It returns an error when it can't find any txt
 // records or if the TXT record is not standard.
-func getRecord(host, path string, ctx context.Context, c Config, r *http.Request) (record, error) {
+func getRecord(host string, ctx context.Context, c Config, r *http.Request) (record, error) {
 	txts, err := query(host, ctx, c)
 	if err != nil {
 		// if nothing found, jump into wildcards
@@ -285,7 +285,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		return nil
 	}
 
-	rec, err := getRecord(host, path, r.Context(), c, r)
+	rec, err := getRecord(host, r.Context(), c, r)
 	if err != nil {
 		if strings.HasSuffix(err.Error(), "no such host") {
 			if c.Redirect != "" {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -173,13 +173,13 @@ func getRecord(host string, ctx context.Context, c Config, r *http.Request) (rec
 	txts, err := query(host, ctx, c)
 	if err != nil {
 		log.Printf("Initial DNS query failed: %s", err)
-		if err != nil || txts[0] == "" {
-			// if error present or record empty, jump into wildcards
-			hostSlice := strings.Split(host, ".")
-			hostSlice[0] = "_"
-			host = strings.Join(hostSlice, ".")
-			txts, err = query(host, ctx, c)
-		}
+	}
+	// if error present or record empty, jump into wildcards
+	if err != nil || txts[0] == "" {
+		hostSlice := strings.Split(host, ".")
+		hostSlice[0] = "_"
+		host = strings.Join(hostSlice, ".")
+		txts, err = query(host, ctx, c)
 		if err != nil {
 			return record{}, err
 		}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -231,8 +231,10 @@ func customResolver(c Config) net.Resolver {
 // query checks the given zone using net.LookupTXT to
 // find TXT records in that zone
 func query(zone string, ctx context.Context, c Config) ([]string, error) {
+	// Removes port from zone
 	if strings.Contains(zone, ":") {
-		return nil, fmt.Errorf("zone should not have a port: %s", zone)
+		zoneSlice := strings.Split(zone, ":")
+		zone = zoneSlice[0]
 	}
 
 	if !strings.HasPrefix(zone, basezone) {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -172,7 +172,14 @@ func contains(array []string, word string) bool {
 func getRecord(host, path string, ctx context.Context, c Config, r *http.Request) (record, error) {
 	txts, err := query(host, ctx, c)
 	if err != nil {
-		return record{}, err
+		// if nothing found, jump into wildcards
+		hostSlice := strings.Split(host, ".")
+		hostSlice[0] = "_"
+		host = strings.Join(hostSlice, ".")
+		txts, err = query(host, ctx, c)
+		if err != nil {
+			return record{}, err
+		}
 	}
 
 	if len(txts) != 1 {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -180,6 +180,16 @@ func getRecord(host, path string, ctx context.Context, c Config, r *http.Request
 		if err != nil {
 			return record{}, err
 		}
+		if txts[0] == "" {
+			// if record empty, jump into wildcards again
+			hostSlice := strings.Split(host, ".")
+			hostSlice[0] = "_"
+			host = strings.Join(hostSlice, ".")
+			txts, err = query(host, ctx, c)
+			if err != nil {
+				return record{}, err
+			}
+		}
 	}
 
 	if len(txts) != 1 {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -172,23 +172,16 @@ func contains(array []string, word string) bool {
 func getRecord(host string, ctx context.Context, c Config, r *http.Request) (record, error) {
 	txts, err := query(host, ctx, c)
 	if err != nil {
-		// if nothing found, jump into wildcards
-		hostSlice := strings.Split(host, ".")
-		hostSlice[0] = "_"
-		host = strings.Join(hostSlice, ".")
-		txts, err = query(host, ctx, c)
-		if err != nil {
-			return record{}, err
-		}
-		if txts[0] == "" {
-			// if record empty, jump into wildcards again
+		log.Printf("Initial DNS query failed: %s", err)
+		if err != nil || txts[0] == "" {
+			// if error present or record empty, jump into wildcards
 			hostSlice := strings.Split(host, ".")
 			hostSlice[0] = "_"
 			host = strings.Join(hostSlice, ".")
 			txts, err = query(host, ctx, c)
-			if err != nil {
-				return record{}, err
-			}
+		}
+		if err != nil {
+			return record{}, err
 		}
 	}
 

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -232,9 +232,9 @@ func customResolver(c Config) net.Resolver {
 // find TXT records in that zone
 func query(zone string, ctx context.Context, c Config) ([]string, error) {
 	// Removes port from zone
-	if strings.Contains(zone, ":") {
-		zoneSlice := strings.Split(zone, ":")
-		zone = zoneSlice[0]
+	zone, _, err := net.SplitHostPort(zone)
+	if err != nil {
+		return nil, err
 	}
 
 	if !strings.HasPrefix(zone, basezone) {
@@ -250,7 +250,6 @@ func query(zone string, ctx context.Context, c Config) ([]string, error) {
 	}
 
 	var txts []string
-	var err error
 	if c.Resolver != "" {
 		net := customResolver(c)
 		txts, err = net.LookupTXT(ctx, absoluteZone)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a query for _redirect._ if the _redirect query isn't found for primary requests. This solves the wildcard issue where we can't set a wildcard _redirect record.

**Which issue this PR fixes**:
fixes #145 