### PR TITLE
Add regex matches as placeholders

### DIFF
--- a/path.go
+++ b/path.go
@@ -20,7 +20,7 @@ var GroupOrderRegex = regexp.MustCompile("P<([a-zA-Z]+[a-zA-Z0-9]*)>")
 // zoneFromPath generates a DNS zone with the given host and path
 // It will use custom regex to parse the path if it's provided in
 // the given record.
-func zoneFromPath(host string, path string, rec record, ps *[]string) (string, int, error) {
+func zoneFromPath(host string, path string, rec record) (string, int, []string, error) {
 	if strings.ContainsAny(path, ".") {
 		path = strings.Replace(path, ".", "-", -1)
 	}
@@ -43,11 +43,10 @@ func zoneFromPath(host string, path string, rec record, ps *[]string) (string, i
 			}
 			url := sortMap(unordered)
 			reverse(url)
-			*ps = pathSlice
 			from := len(pathSlice)
 			url = append(url, host)
 			url = append([]string{basezone}, url...)
-			return strings.Join(url, "."), from, nil
+			return strings.Join(url, "."), from, pathSlice, nil
 		}
 	}
 	pathSlice := []string{}
@@ -71,7 +70,7 @@ func zoneFromPath(host string, path string, rec record, ps *[]string) (string, i
 			keys = append(keys, k)
 		}
 		if len(keys) != len(pathSlice) {
-			return "", 0, fmt.Errorf("length of path doesn't match with length of from= in record")
+			return "", 0, []string{}, fmt.Errorf("length of path doesn't match with length of from= in record")
 		}
 		generatedPath := []string{}
 
@@ -83,13 +82,13 @@ func zoneFromPath(host string, path string, rec record, ps *[]string) (string, i
 
 		url := append(generatedPath, host)
 		url = append([]string{basezone}, url...)
-		return strings.Join(url, "."), from, nil
+		return strings.Join(url, "."), from, pathSlice, nil
 	}
-	*ps = pathSlice
+	ps := pathSlice
 	reverse(pathSlice)
 	url := append(pathSlice, host)
 	url = append([]string{basezone}, url...)
-	return strings.Join(url, "."), from, nil
+	return strings.Join(url, "."), from, ps, nil
 }
 
 // getFinalRecord finds the final TXT record for the given zone.

--- a/path_test.go
+++ b/path_test.go
@@ -154,7 +154,8 @@ func Test_zoneFromPath(t *testing.T) {
 		rec := record{}
 		rec.Re = test.regex
 		rec.From = test.from
-		zone, _, err := zoneFromPath(test.host, test.path, rec)
+		pathSlice := []string{}
+		zone, _, err := zoneFromPath(test.host, test.path, rec, &pathSlice)
 		if err != nil {
 			t.Errorf("Got error: %s", err.Error())
 		}

--- a/path_test.go
+++ b/path_test.go
@@ -154,8 +154,7 @@ func Test_zoneFromPath(t *testing.T) {
 		rec := record{}
 		rec.Re = test.regex
 		rec.From = test.from
-		pathSlice := []string{}
-		zone, _, err := zoneFromPath(test.host, test.path, rec, &pathSlice)
+		zone, _, _, err := zoneFromPath(test.host, test.path, rec)
 		if err != nil {
 			t.Errorf("Got error: %s", err.Error())
 		}

--- a/placeholders.go
+++ b/placeholders.go
@@ -5,13 +5,16 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 )
 
+var PlaceholderRegex = regexp.MustCompile("{[~>?]?\\w+}")
+
 // parsePlaceholders gets a string input and looks for placeholders inside
 // the string. it will then replace them with the actual data from the request
-func parsePlaceholders(input string, r *http.Request) (string, error) {
+func parsePlaceholders(input string, r *http.Request, pathSlice []string) (string, error) {
 	placeholders := PlaceholderRegex.FindAllStringSubmatch(input, -1)
 	for _, placeholder := range placeholders {
 		switch placeholder[0] {
@@ -98,5 +101,10 @@ func parsePlaceholders(input string, r *http.Request) (string, error) {
 			input = strings.Replace(input, placeholder[0], query.Get(name), -1)
 		}
 	}
+
+	for k, v := range pathSlice {
+		input = strings.Replace(input, fmt.Sprintf("{$%d}", k+1), v, -1)
+	}
+
 	return input, nil
 }

--- a/placeholders_test.go
+++ b/placeholders_test.go
@@ -10,102 +10,134 @@ func TestParsePlaceholders(t *testing.T) {
 	tests := []struct {
 		url       string
 		requested string
+		pathSlice []string
 		expected  string
 	}{
 		{
 			"example.com{uri}",
 			"https://example.com/about/test/file.html?query=string&another=value#even-a-fragment",
+			[]string{},
 			"example.com/about/test/file.html?query=string&another=value#even-a-fragment",
 		},
 		{
 			"example.com{uri_escaped}",
 			"https://example.com/about/test/file.html?query=string&another=value#even-a-fragment",
+			[]string{},
 			"example.com%2Fabout%2Ftest%2Ffile.html%3Fquery%3Dstring%26another%3Dvalue%23even-a-fragment",
 		},
 		{
 			"example.com/{~test}",
 			"https://example.com/?test=test",
+			[]string{},
 			"example.com/test",
 		},
 		{
 			"example.com/{>Test}",
 			"https://example.com/?test=test",
+			[]string{},
 			"example.com/test-header",
 		},
 		{
 			"example.com/{?test}",
 			"https://example.com/?test=test",
+			[]string{},
 			"example.com/test",
 		},
 		{
 			"example.com{dir}",
 			"https://example.com/directory/test",
+			[]string{},
 			"example.com/directory/",
 		},
 		{
 			"example.com/directory/{file}",
 			"https://example.com/directory/file.pdf",
+			[]string{},
 			"example.com/directory/file.pdf",
 		},
 		{
 			"example.com/{host}",
 			"https://project.example.com:8080",
+			[]string{},
 			"example.com/project.example.com:8080",
 		},
 		{
 			"example.com/{hostonly}",
 			"https://project.example.com",
+			[]string{},
 			"example.com/project.example.com",
 		},
 		{
 			"example.com/{method}",
 			"https://example.com",
+			[]string{},
 			"example.com/GET",
 		},
 		{
 			"example.com{path}",
 			"https://example.com/this-is-a-test-path/api/v1/",
+			[]string{},
 			"example.com/this-is-a-test-path/api/v1/",
 		},
 		{
 			"example.com{path_escaped}",
 			"https://example.com/path_escaped-test/api/v1",
+			[]string{},
 			"example.com%2Fpath_escaped-test%2Fapi%2Fv1",
 		},
 		{
 			"example.com:{port}",
 			"https://example.com:8080",
+			[]string{},
 			"example.com:8080",
 		},
 		{
 			"example.com/test/{query}",
 			"https://example.com/test/?querykey=queryvalue&anotherquerykey=anothervalue",
+			[]string{},
 			"example.com/test/querykey=queryvalue&anotherquerykey=anothervalue",
 		},
 		{
 			"example.com/test/{query_escaped}",
 			"https://example.com/test/?querykey=queryvalue&anotherquerykey=anothervalue",
+			[]string{},
 			"example.com/test/querykey%3Dqueryvalue%26anotherquerykey%3Danothervalue",
 		},
 		{
 			"example.com/{user}",
 			"https://example.com/user1",
+			[]string{},
 			"example.com/user1",
 		},
 		{
 			"about.example.com/{label1}",
 			"https://about.example.com",
+			[]string{},
 			"about.example.com/about",
 		},
 		{
 			"about.example.com/{label2}",
 			"https://about.example.com",
+			[]string{},
 			"about.example.com/example",
 		},
 		{
 			"about.example.com/{label3}",
 			"https://about.example.com/com",
+			[]string{},
 			"about.example.com/com",
+		},
+		{
+			"about.example.com/{$1}/{$3}/{$2}",
+			"https://about.example.com/this/is/test",
+			[]string{"this", "is", "test"},
+			"about.example.com/this/test/is",
+		},
+		{
+			"about.example.com/{$1}/{$3}/{$2}",
+			"https://about.example.com/123/test/t3st",
+			[]string{"123", "test", "t3st"},
+			"about.example.com/123/t3st/test",
 		},
 	}
 	for _, test := range tests {
@@ -113,7 +145,7 @@ func TestParsePlaceholders(t *testing.T) {
 		req.AddCookie(&http.Cookie{Name: "test", Value: "test"})
 		req.Header.Add("Test", "test-header")
 		req.SetBasicAuth("user1", "password")
-		result, err := parsePlaceholders(test.url, req)
+		result, err := parsePlaceholders(test.url, req, test.pathSlice)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -126,24 +158,28 @@ func TestParsePlaceholders(t *testing.T) {
 func TestParsePlaceholdersFails(t *testing.T) {
 	tests := []struct {
 		url       string
+		pathSlice []string
 		requested string
 	}{
 		{
 			"example.com/{label0}",
+			[]string{},
 			"https://example.com/test",
 		},
 		{
 			"example.com/{label9000}",
+			[]string{},
 			"https://example.com/test",
 		},
 		{
 			"example.com/{labelxyz}",
+			[]string{},
 			"https://example.com/test",
 		},
 	}
 	for _, test := range tests {
 		req := httptest.NewRequest("GET", test.requested, nil)
-		_, err := parsePlaceholders(test.url, req)
+		_, err := parsePlaceholders(test.url, req, test.pathSlice)
 		if err == nil {
 			t.Errorf("Expected error, got nil")
 		}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -37,8 +36,6 @@ const (
 	logFormat       = "02/Jan/2006:15:04:05 -0700"
 	proxyTimeout    = 30 * time.Second
 )
-
-var PlaceholderRegex = regexp.MustCompile("{[~>?]?\\w+}")
 
 type record struct {
 	Version string
@@ -77,7 +74,7 @@ func (r *record) Parse(str string, req *http.Request, c Config) error {
 
 		case strings.HasPrefix(l, "from="):
 			l = strings.TrimPrefix(l, "from=")
-			l, err := parsePlaceholders(l, req)
+			l, err := parsePlaceholders(l, req, []string{})
 			if err != nil {
 				return err
 			}
@@ -93,7 +90,7 @@ func (r *record) Parse(str string, req *http.Request, c Config) error {
 
 		case strings.HasPrefix(l, "to="):
 			l = strings.TrimPrefix(l, "to=")
-			l, err := parsePlaceholders(l, req)
+			l, err := parsePlaceholders(l, req, []string{})
 			if err != nil {
 				return err
 			}
@@ -153,7 +150,7 @@ func (r *record) Parse(str string, req *http.Request, c Config) error {
 // and returns the final address and http status code
 func getBaseTarget(rec record, r *http.Request) (string, int, error) {
 	if strings.ContainsAny(rec.To, "{}") {
-		to, err := parsePlaceholders(rec.To, r)
+		to, err := parsePlaceholders(rec.To, r, []string{})
 		if err != nil {
 			return "", 0, err
 		}
@@ -332,8 +329,9 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		}
 
 		if path != "" {
-			zone, from, err := zoneFromPath(host, path, rec)
-			rec, err = getFinalRecord(zone, from, r.Context(), c, r)
+			pathSlice := []string{}
+			zone, from, err := zoneFromPath(host, path, rec, &pathSlice)
+			rec, err = getFinalRecord(zone, from, r.Context(), c, r, pathSlice)
 			if err != nil {
 				log.Print("Fallback is triggered because an error has occurred: ", err)
 				fallback(w, r, fallbackURL, code, c)

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -329,8 +329,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		}
 
 		if path != "" {
-			pathSlice := []string{}
-			zone, from, err := zoneFromPath(host, path, rec, &pathSlice)
+			zone, from, pathSlice, err := zoneFromPath(host, path, rec)
 			rec, err = getFinalRecord(zone, from, r.Context(), c, r, pathSlice)
 			if err != nil {
 				log.Print("Fallback is triggered because an error has occurred: ", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds regex matches as placeholders

**Which issue this PR fixes**:
fixes #148 


**Special notes for your reviewer**:
I've passed ``pathSlice`` as a pointer to zoneFromPath because I didn't want to return more than 3 variables. If it's ok to be more than 3, can change it.

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
