### PR TITLE
[logging]: Remove custom time format and add host data to logs

### DIFF
--- a/dockerv2.go
+++ b/dockerv2.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"time"
 )
 
 var dockerRegexes = map[string]*regexp.Regexp{
@@ -17,7 +16,7 @@ var dockerRegexes = map[string]*regexp.Regexp{
 func redirectDockerv2(w http.ResponseWriter, r *http.Request, rec record) error {
 	path := r.URL.Path
 	if !strings.HasPrefix(path, "/v2") {
-		log.Printf("<%s> [txtdirect]: unrecognized path for dockerv2: %s", time.Now().Format(logFormat), path)
+		log.Printf("[txtdirect]: unrecognized path for dockerv2: %s", path)
 		if path == "" || path == "/" {
 			fallback(w, r, rec.Root, http.StatusPermanentRedirect, Config{})
 			return nil

--- a/prometheus.go
+++ b/prometheus.go
@@ -69,7 +69,7 @@ func (p *Prometheus) start() error {
 		go func() {
 			err := http.ListenAndServe(p.Address, nil)
 			if err != nil {
-				log.Printf("<%s> [txtdirect]: Couldn't start http handler for prometheus metrics. %s", time.Now().Format(logFormat), err.Error())
+				log.Printf("[txtdirect]: Couldn't start http handler for prometheus metrics. %s", err.Error())
 			}
 		}()
 	})

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -33,7 +33,6 @@ const (
 	defaultProtocol = "https"
 	proxyKeepalive  = 30
 	fallbackDelay   = 300 * time.Millisecond
-	logFormat       = "02/Jan/2006:15:04:05 -0700"
 	proxyTimeout    = 30 * time.Second
 )
 
@@ -128,7 +127,7 @@ func (r *record) Parse(str string, req *http.Request, c Config) error {
 			return fmt.Errorf("TXT record cannot exceed the maximum of 255 characters")
 		}
 		if r.Type == "dockerv2" && r.To == "" {
-			return fmt.Errorf("<%s> [txtdirect]: to= field is required in dockerv2 type", time.Now().Format(logFormat))
+			return fmt.Errorf("[txtdirect]: to= field is required in dockerv2 type")
 		}
 	}
 
@@ -209,7 +208,7 @@ func getRecord(host string, ctx context.Context, c Config, r *http.Request) (rec
 // default fallback address
 func fallback(w http.ResponseWriter, r *http.Request, fallback string, code int, c Config) {
 	if fallback != "" {
-		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), fallback)
+		log.Printf("[txtdirect]: %s > %s", r.URL.String(), fallback)
 		http.Redirect(w, r, fallback, code)
 		if c.Prometheus.Enable {
 			RequestsByStatus.WithLabelValues(r.URL.Host, string(code)).Add(1)
@@ -217,7 +216,7 @@ func fallback(w http.ResponseWriter, r *http.Request, fallback string, code int,
 	} else if c.Redirect != "" {
 		for _, enable := range c.Enable {
 			if enable == "www" {
-				log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), c.Redirect)
+				log.Printf("[txtdirect]: %s > %s", r.URL.String(), c.Redirect)
 				http.Redirect(w, r, c.Redirect, http.StatusForbidden)
 				if c.Prometheus.Enable {
 					RequestsByStatus.WithLabelValues(r.URL.Host, string(http.StatusForbidden)).Add(1)
@@ -288,7 +287,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 
 	if bl[path] {
 		redirect := strings.Join([]string{host, path}, "")
-		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), redirect)
+		log.Printf("[txtdirect]: %s > %s", r.URL.String(), redirect)
 		http.Redirect(w, r, redirect, http.StatusOK)
 		if c.Prometheus.Enable {
 			RequestsByStatus.WithLabelValues(host, string(http.StatusOK)).Add(1)
@@ -300,7 +299,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	if err != nil {
 		if strings.HasSuffix(err.Error(), "no such host") {
 			if c.Redirect != "" {
-				log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), c.Redirect)
+				log.Printf("[txtdirect]: %s > %s", r.URL.String(), c.Redirect)
 				http.Redirect(w, r, c.Redirect, http.StatusMovedPermanently)
 				if c.Prometheus.Enable {
 					RequestsByStatus.WithLabelValues(host, string(http.StatusMovedPermanently)).Add(1)
@@ -309,7 +308,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 			}
 			if contains(c.Enable, "www") {
 				s := strings.Join([]string{defaultProtocol, "://", defaultSub, ".", host}, "")
-				log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), s)
+				log.Printf("[txtdirect]: %s > %s", r.URL.String(), s)
 				http.Redirect(w, r, s, http.StatusMovedPermanently)
 				if c.Prometheus.Enable {
 					RequestsByStatus.WithLabelValues(host, string(http.StatusMovedPermanently)).Add(1)
@@ -345,7 +344,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 				fallback(w, r, fallbackURL, code, c)
 				return nil
 			}
-			log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), rec.Root)
+			log.Printf("[txtdirect]: %s > %s", r.URL.String(), rec.Root)
 			http.Redirect(w, r, rec.Root, rec.Code)
 			if c.Prometheus.Enable {
 				RequestsByStatus.WithLabelValues(host, string(rec.Code)).Add(1)
@@ -365,7 +364,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	}
 
 	if rec.Type == "proxy" {
-		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), rec.From, rec.To)
+		log.Printf("[txtdirect]: %s > %s", rec.From, rec.To)
 		to, _, err := getBaseTarget(rec, r)
 		if err != nil {
 			log.Print("Fallback is triggered because an error has occurred: ", err)
@@ -384,7 +383,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	if rec.Type == "dockerv2" {
 		err := redirectDockerv2(w, r, rec)
 		if err != nil {
-			log.Printf("<%s> [txtdirect]: couldn't redirect to the requested container: %s", time.Now().Format(logFormat), err.Error())
+			log.Printf("[txtdirect]: couldn't redirect to the requested container: %s", err.Error())
 			fallback(w, r, fallbackURL, code, c)
 		}
 		return nil
@@ -397,7 +396,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 			fallback(w, r, fallbackURL, code, c)
 			return err
 		}
-		log.Printf("<%s> [txtdirect]: %s > %s", time.Now().Format(logFormat), r.URL.String(), to)
+		log.Printf("[txtdirect]: %s > %s", r.URL.String(), to)
 		http.Redirect(w, r, to, code)
 		if c.Prometheus.Enable {
 			RequestsByStatus.WithLabelValues(host, string(code)).Add(1)

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -208,7 +208,7 @@ func getRecord(host string, ctx context.Context, c Config, r *http.Request) (rec
 // default fallback address
 func fallback(w http.ResponseWriter, r *http.Request, fallback string, code int, c Config) {
 	if fallback != "" {
-		log.Printf("[txtdirect]: %s > %s", r.URL.String(), fallback)
+		log.Printf("[txtdirect]: %s > %s", r.Host+r.URL.Path, fallback)
 		http.Redirect(w, r, fallback, code)
 		if c.Prometheus.Enable {
 			RequestsByStatus.WithLabelValues(r.URL.Host, string(code)).Add(1)
@@ -216,7 +216,7 @@ func fallback(w http.ResponseWriter, r *http.Request, fallback string, code int,
 	} else if c.Redirect != "" {
 		for _, enable := range c.Enable {
 			if enable == "www" {
-				log.Printf("[txtdirect]: %s > %s", r.URL.String(), c.Redirect)
+				log.Printf("[txtdirect]: %s > %s", r.Host+r.URL.Path, c.Redirect)
 				http.Redirect(w, r, c.Redirect, http.StatusForbidden)
 				if c.Prometheus.Enable {
 					RequestsByStatus.WithLabelValues(r.URL.Host, string(http.StatusForbidden)).Add(1)
@@ -287,7 +287,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 
 	if bl[path] {
 		redirect := strings.Join([]string{host, path}, "")
-		log.Printf("[txtdirect]: %s > %s", r.URL.String(), redirect)
+		log.Printf("[txtdirect]: %s > %s", r.Host+r.URL.Path, redirect)
 		http.Redirect(w, r, redirect, http.StatusOK)
 		if c.Prometheus.Enable {
 			RequestsByStatus.WithLabelValues(host, string(http.StatusOK)).Add(1)
@@ -299,7 +299,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	if err != nil {
 		if strings.HasSuffix(err.Error(), "no such host") {
 			if c.Redirect != "" {
-				log.Printf("[txtdirect]: %s > %s", r.URL.String(), c.Redirect)
+				log.Printf("[txtdirect]: %s > %s", r.Host+r.URL.Path, c.Redirect)
 				http.Redirect(w, r, c.Redirect, http.StatusMovedPermanently)
 				if c.Prometheus.Enable {
 					RequestsByStatus.WithLabelValues(host, string(http.StatusMovedPermanently)).Add(1)
@@ -308,7 +308,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 			}
 			if contains(c.Enable, "www") {
 				s := strings.Join([]string{defaultProtocol, "://", defaultSub, ".", host}, "")
-				log.Printf("[txtdirect]: %s > %s", r.URL.String(), s)
+				log.Printf("[txtdirect]: %s > %s", r.Host+r.URL.Path, s)
 				http.Redirect(w, r, s, http.StatusMovedPermanently)
 				if c.Prometheus.Enable {
 					RequestsByStatus.WithLabelValues(host, string(http.StatusMovedPermanently)).Add(1)
@@ -344,7 +344,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 				fallback(w, r, fallbackURL, code, c)
 				return nil
 			}
-			log.Printf("[txtdirect]: %s > %s", r.URL.String(), rec.Root)
+			log.Printf("[txtdirect]: %s > %s", r.Host+r.URL.Path, rec.Root)
 			http.Redirect(w, r, rec.Root, rec.Code)
 			if c.Prometheus.Enable {
 				RequestsByStatus.WithLabelValues(host, string(rec.Code)).Add(1)
@@ -396,7 +396,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 			fallback(w, r, fallbackURL, code, c)
 			return err
 		}
-		log.Printf("[txtdirect]: %s > %s", r.URL.String(), to)
+		log.Printf("[txtdirect]: %s > %s", r.Host+r.URL.Path, to)
 		http.Redirect(w, r, to, code)
 		if c.Prometheus.Enable {
 			RequestsByStatus.WithLabelValues(host, string(code)).Add(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes custom time format from logs and adds host data to logs instead of using `r.URL.String()`

**Which issue this PR fixes**:
fixes #167 and #168 


**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
