### PR TITLE
Trigger fallback when the request's host is an IP

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -279,6 +279,15 @@ func query(zone string, ctx context.Context, c Config) ([]string, error) {
 	return txts, nil
 }
 
+func isIP(host string) bool {
+	hostSlice := strings.Split(host, ".")
+	_, err := strconv.Atoi(hostSlice[len(hostSlice)-1])
+	if err == nil {
+		return true
+	}
+	return false
+}
+
 // Redirect the request depending on the redirect record found
 func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	host := r.Host
@@ -301,7 +310,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		return nil
 	}
 
-	if host == "127.0.0.1" {
+	if isIP(host) {
 		log.Println("[txtdirect]: Trying to access 127.0.0.1, fallback triggered.")
 		fallback(w, r, "", 0, c)
 		return nil

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -280,12 +280,12 @@ func query(zone string, ctx context.Context, c Config) ([]string, error) {
 }
 
 func isIP(host string) bool {
-	hostSlice := strings.Split(host, ".")
-	_, err := strconv.Atoi(hostSlice[len(hostSlice)-1])
-	if err == nil {
+	if v6slice := strings.Split(host, ":"); len(v6slice) > 2 {
 		return true
 	}
-	return false
+	hostSlice := strings.Split(host, ".")
+	_, err := strconv.Atoi(hostSlice[len(hostSlice)-1])
+	return err == nil
 }
 
 // Redirect the request depending on the redirect record found

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -301,6 +301,12 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		return nil
 	}
 
+	if host == "127.0.0.1" {
+		log.Println("[txtdirect]: Trying to access 127.0.0.1, fallback triggered.")
+		fallback(w, r, "", 0, c)
+		return nil
+	}
+
 	rec, err := getRecord(host, r.Context(), c, r)
 	if err != nil {
 		if strings.HasSuffix(err.Error(), "no such host") {

--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -370,6 +370,18 @@ func TestRedirectE2e(t *testing.T) {
 			"https://github.com/okkur/reposeed",
 			[]string{"gometa", "path"},
 		},
+		{
+			"https://127.0.0.1/test",
+			txts["_redirect.fail.record."],
+			"404",
+			[]string{"host"},
+		},
+		{
+			"https://192.168.1.2",
+			txts["_redirect.fail.record."],
+			"404",
+			[]string{"host"},
+		},
 	}
 	for _, test := range tests {
 		req := httptest.NewRequest("GET", test.url, nil)

--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -382,12 +382,18 @@ func TestRedirectE2e(t *testing.T) {
 			txts["_redirect.fail.record."],
 			"404",
 			[]string{"host"},
-    },
-    {
-			"https://metapath.e2e.test/pkgweb",
-			txts["_redirect.metapath.e2e.test."],
-			"https://godoc.org/go.txtdirect.org/txtdirect",
-			[]string{"gometa", "path"},
+		},
+		{
+			"https://2001:db8:1234:0000:0000:0000:0000:0000",
+			txts["_redirect.fail.record."],
+			"404",
+			[]string{"host"},
+		},
+		{
+			"https://2001:db8:1234::/48",
+			txts["_redirect.fail.record."],
+			"404",
+			[]string{"host"},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
Triggers fallback when the request is for 127.0.0.1

**Which issue this PR fixes**:
fixes #190 