### PR TITLE
[gometa]: Remove .Path from meta tags

### DIFF
--- a/gometa_test.go
+++ b/gometa_test.go
@@ -22,13 +22,11 @@ import (
 func TestGometa(t *testing.T) {
 	tests := []struct {
 		host     string
-		path     string
 		record   record
 		expected string
 	}{
 		{
 			host: "example.com",
-			path: "/test",
 			record: record{
 				Vcs: "git",
 				To:  "redirect.com/my-go-pkg",
@@ -36,26 +34,24 @@ func TestGometa(t *testing.T) {
 			expected: `<!DOCTYPE html>
 <html>
 <head>
-<meta name="go-import" content="example.com/test git redirect.com/my-go-pkg">
+<meta name="go-import" content="example.com git redirect.com/my-go-pkg">
 
 </head>
 </html>`,
 		},
 		{
 			host:   "empty.com",
-			path:   "/test",
 			record: record{},
 			expected: `<!DOCTYPE html>
 <html>
 <head>
-<meta name="go-import" content="empty.com/test git ">
+<meta name="go-import" content="empty.com git ">
 
 </head>
 </html>`,
 		},
 		{
 			host: "root.com",
-			path: "/",
 			record: record{
 				Vcs: "git",
 				To:  "redirect.com/my-root-package",
@@ -70,7 +66,6 @@ func TestGometa(t *testing.T) {
 		},
 		{
 			host: "root.com",
-			path: "/",
 			record: record{
 				Vcs: "git",
 				To:  "github.com/txtdirect/txtdirect",
@@ -87,7 +82,7 @@ func TestGometa(t *testing.T) {
 
 	for i, test := range tests {
 		rec := httptest.NewRecorder()
-		err := gometa(rec, test.record, test.host, test.path)
+		err := gometa(rec, test.record, test.host)
 		if err != nil {
 			t.Errorf("Test %d: Unexpected error: %s", i, err)
 			continue
@@ -100,13 +95,5 @@ func TestGometa(t *testing.T) {
 		if got, want := string(txt), test.expected; got != want {
 			t.Errorf("Test %d:\nExpected\n%s\nto be:\n%s", i, got, want)
 		}
-	}
-}
-
-func TestInternalFolderInPath(t *testing.T) {
-	rec := httptest.NewRecorder()
-	err := gometa(rec, record{}, "example.com", "/test/internal")
-	if err == nil {
-		t.Errorf("Expected to get an error when '/internal' folder included in path")
 	}
 }

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -420,7 +420,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	}
 
 	if rec.Type == "gometa" {
-		return gometa(w, rec, host, path)
+		return gometa(w, rec, host)
 	}
 
 	if rec.Type == "gomods" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes .Path from meta tags

**Which issue this PR fixes**:
fixes #201 
