### PR TITLE
[fallback]: Fix missing argument in the function call

### DIFF
--- a/txtdirect.go
+++ b/txtdirect.go
@@ -314,7 +314,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 
 	if isIP(host) {
 		log.Println("[txtdirect]: Trying to access 127.0.0.1, fallback triggered.")
-		fallback(w, r, "", 0, c)
+		fallback(w, r, "", "", 0, c)
 		return nil
 	}
 

--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -495,7 +495,7 @@ func Test_fallback(t *testing.T) {
 			Redirect: test.redirect,
 			Enable:   []string{"www"},
 		}
-		fallback(resp, req, test.url, test.code, c)
+		fallback(resp, req, test.url, "test", test.code, c)
 		if resp.Code != test.code {
 			t.Errorf("Response's status code (%d) doesn't match with expected status code (%d).", resp.Code, test.code)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes missing argument in the function call.

P.S: This bug causes master tests to fail.