### PR TITLE
[header]: Replace "Server" header value with "TXTDirect"

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -192,6 +192,8 @@ type Redirect struct {
 }
 
 func (rd Redirect) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
+	w.Header().Set("Server", "TXTDirect")
+
 	if err := txtdirect.Redirect(w, r, rd.Config); err != nil {
 		if err.Error() == "option disabled" {
 			return rd.Next.ServeHTTP(w, r)

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -192,8 +192,6 @@ type Redirect struct {
 }
 
 func (rd Redirect) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
-	w.Header().Set("Server", "TXTDirect")
-
 	if err := txtdirect.Redirect(w, r, rd.Config); err != nil {
 		if err.Error() == "option disabled" {
 			return rd.Next.ServeHTTP(w, r)

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -294,6 +294,8 @@ func isIP(host string) bool {
 
 // Redirect the request depending on the redirect record found
 func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
+	w.Header().Set("Server", "TXTDirect")
+
 	host := r.Host
 	path := r.URL.Path
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Replaces "Server" header value with "TXTDirect"

**Which issue this PR fixes**:
fixes #221 
