### PR TITLE
Inherit dependency versions from Caddy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,10 @@ recipe:
 dependencies:
 	if [ -d caddy-copy ]; then cd caddy-copy && git checkout . && git pull && cd ..; else git clone https://github.com/mholt/caddy caddy-copy; fi
 	cd caddy-copy && \
-	if [ -f go.mod ]; then echo "already initialized go modules"; else go mod init; fi && \
 	if ! grep -q "txtdirect => ../" go.mod; then \
 		echo -e "\nreplace github.com/txtdirect/txtdirect => ../" >> go.mod && \
 		echo "replace github.com/mholt/caddy => ../caddy-copy" >> go.mod; \
 	fi && \
-	GO111MODULE=on go get github.com/lucas-clemente/quic-go@master && \
-	GO111MODULE=on go get github.com/russross/blackfriday@master && \
-	GO111MODULE=on go get github.com/txtdirect/txtdirect@master && \
-	GO111MODULE=on go get github.com/SchumacherFM/mailout && \
-	GO111MODULE=on go get github.com/captncraig/caddy-realip && \
-	GO111MODULE=on go get github.com/miekg/caddy-prometheus && \
 	cd ..
 
 build: dependencies recipe


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:
Remove manual version pinning from makefile as these are now set within Caddy itself.

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
