### PR TITLE
[header]: Add referer header

### DIFF
--- a/record.go
+++ b/record.go
@@ -33,6 +33,7 @@ type record struct {
 	From    string
 	Root    string
 	Re      string
+	Ref     bool
 }
 
 // getRecord uses the given host to find a TXT record
@@ -97,6 +98,14 @@ func (r *record) Parse(str string, w http.ResponseWriter, req *http.Request, c C
 		case strings.HasPrefix(l, "re="):
 			l = strings.TrimPrefix(l, "re=")
 			r.Re = l
+
+		case strings.HasPrefix(l, "ref="):
+			l, err := strconv.ParseBool(strings.TrimPrefix(l, "ref="))
+			if err != nil {
+				fallback(w, req, "global", http.StatusMovedPermanently, c)
+				return err
+			}
+			r.Ref = l
 
 		case strings.HasPrefix(l, "root="):
 			l = strings.TrimPrefix(l, "root=")

--- a/record_test.go
+++ b/record_test.go
@@ -135,6 +135,26 @@ func TestParse(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"v=txtv0;ref=true;code=302",
+			record{
+				Version: "txtv0",
+				Type:    "host",
+				Code:    302,
+				Ref:     true,
+			},
+			nil,
+		},
+		{
+			"v=txtv0;ref=false;code=302",
+			record{
+				Version: "txtv0",
+				Type:    "host",
+				Code:    302,
+				Ref:     false,
+			},
+			nil,
+		},
 	}
 
 	for i, test := range tests {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -128,16 +128,6 @@ func isIP(host string) bool {
 func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	w.Header().Set("Server", "TXTDirect")
 
-	// Add referer header
-	if r.Header.Get("Referer") == "" {
-		host := r.Host
-		if strings.Contains(host, ":") {
-			hostSlice := strings.Split(host, ":")
-			host = hostSlice[0]
-		}
-		w.Header().Set("Referer", host)
-	}
-
 	host := r.Host
 	path := r.URL.Path
 
@@ -168,6 +158,16 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	if err != nil {
 		fallback(w, r, "global", http.StatusFound, c)
 		return nil
+	}
+
+	// Add referer header
+	if rec.Ref && r.Header.Get("Referer") == "" {
+		host := r.Host
+		if strings.Contains(host, ":") {
+			hostSlice := strings.Split(host, ":")
+			host = hostSlice[0]
+		}
+		w.Header().Set("Referer", host)
 	}
 
 	if !contains(c.Enable, rec.Type) {

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -128,6 +128,16 @@ func isIP(host string) bool {
 func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	w.Header().Set("Server", "TXTDirect")
 
+	// Add referer header
+	if r.Header.Get("Referer") == "" {
+		host := r.Host
+		if strings.Contains(host, ":") {
+			hostSlice := strings.Split(host, ":")
+			host = hostSlice[0]
+		}
+		w.Header().Set("Referer", host)
+	}
+
 	host := r.Host
 	path := r.URL.Path
 

--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -34,7 +34,7 @@ import (
 // Testing TXT records
 var txts = map[string]string{
 	// type=host
-	"_redirect.host.e2e.test.":           "v=txtv0;to=https://plain.host.test;type=host;code=302",
+	"_redirect.host.e2e.test.":           "v=txtv0;to=https://plain.host.test;type=host;ref=true;code=302",
 	"_redirect.nocode.host.e2e.test.":    "v=txtv0;to=https://nocode.host.test;type=host",
 	"_redirect.noversion.host.e2e.test.": "to=https://noversion.host.test;type=host",
 	"_redirect.noto.host.e2e.test.":      "v=txtv0;type=host",

--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -170,86 +170,93 @@ func TestRedirectE2e(t *testing.T) {
 		url      string
 		expected string
 		enable   []string
+		referer  bool
 	}{
 		{
-			"https://host.e2e.test",
-			"https://plain.host.test",
-			[]string{"host"},
+			url:      "https://host.e2e.test",
+			expected: "https://plain.host.test",
+			enable:   []string{"host"},
 		},
 		{
-			"https://nocode.host.e2e.test",
-			"https://nocode.host.test",
-			[]string{"host"},
+			url:      "https://nocode.host.e2e.test",
+			expected: "https://nocode.host.test",
+			enable:   []string{"host"},
 		},
 		{
-			"https://noversion.host.e2e.test",
-			"https://noversion.host.test",
-			[]string{"host"},
+			url:      "https://noversion.host.e2e.test",
+			expected: "https://noversion.host.test",
+			enable:   []string{"host"},
 		},
 		{
-			"https://noto.host.e2e.test",
-			"",
-			[]string{"host"},
+			url:      "https://noto.host.e2e.test",
+			expected: "",
+			enable:   []string{"host"},
 		},
 		{
-			"https://path.e2e.test/",
-			"https://root.fallback.test",
-			[]string{"path", "host"},
+			url:      "https://path.e2e.test/",
+			expected: "https://root.fallback.test",
+			enable:   []string{"path", "host"},
 		},
 		{
-			"https://path.e2e.test/nocode",
-			"https://nocode.fallback.path.test",
-			[]string{"path", "host"},
+			url:      "https://path.e2e.test/nocode",
+			expected: "https://nocode.fallback.path.test",
+			enable:   []string{"path", "host"},
 		},
 		{
-			"https://path.e2e.test/noversion",
-			"https://noversion.fallback.path.test",
-			[]string{"path", "host"},
+			url:      "https://path.e2e.test/noversion",
+			expected: "https://noversion.fallback.path.test",
+			enable:   []string{"path", "host"},
 		},
 		{
-			"https://path.e2e.test/noto",
-			"",
-			[]string{"path", "host"},
+			url:      "https://path.e2e.test/noto",
+			expected: "",
+			enable:   []string{"path", "host"},
 		},
 		{
-			"https://path.e2e.test/noroot",
-			"https://noroot.fallback.path.test",
-			[]string{"path", "host"},
+			url:      "https://path.e2e.test/noroot",
+			expected: "https://noroot.fallback.path.test",
+			enable:   []string{"path", "host"},
 		},
 		{
-			"https://pkg.txtdirect.test?go-get=1",
-			"https://github.com/txtdirect/txtdirect",
-			[]string{"gometa"},
+			url:      "https://pkg.txtdirect.test?go-get=1",
+			expected: "https://github.com/txtdirect/txtdirect",
+			enable:   []string{"gometa"},
 		},
 		{
-			"https://metapath.e2e.test/pkg?go-get=1",
-			"https://github.com/okkur/reposeed-server",
-			[]string{"gometa", "path"},
+			url:      "https://metapath.e2e.test/pkg?go-get=1",
+			expected: "https://github.com/okkur/reposeed-server",
+			enable:   []string{"gometa", "path"},
 		},
 		{
-			"https://metapath.e2e.test/pkg/second?go-get=1",
-			"https://github.com/okkur/reposeed",
-			[]string{"gometa", "path"},
+			url:      "https://metapath.e2e.test/pkg/second?go-get=1",
+			expected: "https://github.com/okkur/reposeed",
+			enable:   []string{"gometa", "path"},
 		},
 		{
-			"https://127.0.0.1/test",
-			"404",
-			[]string{"host"},
+			url:      "https://127.0.0.1/test",
+			expected: "404",
+			enable:   []string{"host"},
 		},
 		{
-			"https://192.168.1.2",
-			"404",
-			[]string{"host"},
+			url:      "https://192.168.1.2",
+			expected: "404",
+			enable:   []string{"host"},
 		},
 		{
-			"https://2001:db8:1234:0000:0000:0000:0000:0000",
-			"404",
-			[]string{"host"},
+			url:      "https://2001:db8:1234:0000:0000:0000:0000:0000",
+			expected: "404",
+			enable:   []string{"host"},
 		},
 		{
-			"https://2001:db8:1234::/48",
-			"404",
-			[]string{"host"},
+			url:      "https://2001:db8:1234::/48",
+			expected: "404",
+			enable:   []string{"host"},
+		},
+		{
+			url:      "https://host.e2e.test",
+			expected: "https://plain.host.test",
+			enable:   []string{"host"},
+			referer:  true,
 		},
 	}
 	for _, test := range tests {
@@ -264,6 +271,9 @@ func TestRedirectE2e(t *testing.T) {
 		}
 		if !strings.Contains(resp.Body.String(), test.expected) {
 			t.Errorf("Expected %s to be in \"%s\"", test.expected, resp.Body.String())
+		}
+		if test.referer && resp.Header().Get("Referer") != req.Host {
+			t.Errorf("Expected %s referer but got \"%s\"", req.Host, resp.Header().Get("Referer"))
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `Referer` header and `ref=` field to record struct

**Which issue this PR fixes**:
fixes #273 


