### PR TITLE
[redirect]: Move types logic to their own file

### DIFF
--- a/dockerv2_test.go
+++ b/dockerv2_test.go
@@ -114,8 +114,9 @@ func Test_generateDockerv2URI(t *testing.T) {
 		req := httptest.NewRequest("GET", fmt.Sprintf("https://example.com%s", test.path), nil)
 		resp := httptest.NewRecorder()
 		req = test.rec.addToContext(req)
-		err := redirectDockerv2(resp, req, test.rec)
-		if err != nil {
+		docker := NewDockerv2(resp, req, test.rec, Config{})
+
+		if err := docker.Redirect(); err != nil {
 			t.Errorf("Unexpected error happened: %s", err)
 		}
 		if !strings.Contains(resp.Body.String(), test.expected) {

--- a/dockerv2_test.go
+++ b/dockerv2_test.go
@@ -113,7 +113,7 @@ func Test_generateDockerv2URI(t *testing.T) {
 	for _, test := range tests {
 		req := httptest.NewRequest("GET", fmt.Sprintf("https://example.com%s", test.path), nil)
 		resp := httptest.NewRecorder()
-		req = addRecordToContext(req, test.rec)
+		req = test.rec.addToContext(req)
 		err := redirectDockerv2(resp, req, test.rec)
 		if err != nil {
 			t.Errorf("Unexpected error happened: %s", err)

--- a/fallback_test.go
+++ b/fallback_test.go
@@ -75,7 +75,7 @@ func Test_fallback(t *testing.T) {
 			url = test.url
 		}
 		req := httptest.NewRequest("GET", url, nil)
-		req = addRecordToContext(req, test.record)
+		req = test.record.addToContext(req)
 		resp := httptest.NewRecorder()
 		c := Config{
 			Redirect: test.redirect,

--- a/gometa_test.go
+++ b/gometa_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package txtdirect
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
 	"testing"
@@ -86,13 +87,15 @@ func TestGometa(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		rec := httptest.NewRecorder()
-		err := gometa(rec, test.record, test.host, test.path)
-		if err != nil {
+		req := httptest.NewRequest("GET", fmt.Sprintf("https://%s%s", test.host, test.path), nil)
+		resp := httptest.NewRecorder()
+		gometa := NewGometa(resp, req, test.record, Config{})
+
+		if err := gometa.Serve(); err != nil {
 			t.Errorf("Test %d: Unexpected error: %s", i, err)
 			continue
 		}
-		txt, err := ioutil.ReadAll(rec.Body)
+		txt, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("Test %d: Unexpected error: %s", i, err)
 			continue

--- a/host.go
+++ b/host.go
@@ -1,0 +1,44 @@
+package txtdirect
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+)
+
+type Host struct {
+	rw  http.ResponseWriter
+	req *http.Request
+	c   Config
+	rec record
+}
+
+func NewHost(w http.ResponseWriter, r *http.Request, rec record, c Config) *Host {
+	return &Host{
+		rw:  w,
+		req: r,
+		rec: rec,
+		c:   c,
+	}
+}
+
+// Redirect redirects the request to the endpoint defined in the record
+func (h *Host) Redirect() error {
+	to, code, err := getBaseTarget(h.rec, h.req)
+	if err != nil {
+		log.Print("Fallback is triggered because an error has occurred: ", err)
+		fallback(h.rw, h.req, "to", code, h.c)
+		return nil
+	}
+	log.Printf("[txtdirect]: %s > %s", h.req.Host+h.req.URL.Path, to)
+	if code == http.StatusMovedPermanently {
+		h.rw.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d", status301CacheAge))
+	}
+	h.rw.Header().Add("Status-Code", strconv.Itoa(code))
+	http.Redirect(h.rw, h.req, to, code)
+	if h.c.Prometheus.Enable {
+		RequestsByStatus.WithLabelValues(h.req.Host, strconv.Itoa(code)).Add(1)
+	}
+	return nil
+}

--- a/path.go
+++ b/path.go
@@ -25,10 +25,64 @@ import (
 	"time"
 )
 
+// Path contains the data that are needed to redirect path requests
+type Path struct {
+	rw  http.ResponseWriter
+	req *http.Request
+	c   Config
+
+	path string
+	rec  record
+}
+
 var PathRegex = regexp.MustCompile("\\/([A-Za-z0-9-._~!$'()*+,;=:@]+)")
 var FromRegex = regexp.MustCompile("\\/\\$(\\d+)")
 var GroupRegex = regexp.MustCompile("P<[a-zA-Z]+[a-zA-Z0-9]*>")
 var GroupOrderRegex = regexp.MustCompile("P<([a-zA-Z]+[a-zA-Z0-9]*)>")
+
+// NewPath returns an instance of Path struct using the given data
+func NewPath(w http.ResponseWriter, r *http.Request, path string, rec record, c Config) *Path {
+	return &Path{
+		rw:   w,
+		req:  r,
+		path: path,
+		rec:  rec,
+		c:    c,
+	}
+}
+
+// Redirect finds and returns the final record
+func (p *Path) Redirect() *record {
+	zone, from, pathSlice, err := zoneFromPath(p.req, p.rec)
+	rec, err := getFinalRecord(zone, from, p.c, p.rw, p.req, pathSlice)
+	*p.req = *rec.addToContext(p.req)
+	if err != nil {
+		log.Print("Fallback is triggered because an error has occurred: ", err)
+		fallback(p.rw, p.req, "to", p.rec.Code, p.c)
+		return nil
+	}
+	return &rec
+}
+
+// RedirectRoot redirects the request to record's root= field
+// if the path is empty or "/". If the root= field is empty too
+// fallback will be triggered.
+func (p *Path) RedirectRoot() error {
+	if p.rec.Root == "" {
+		fallback(p.rw, p.req, "to", p.rec.Code, p.c)
+		return nil
+	}
+	log.Printf("[txtdirect]: %s > %s", p.req.Host+p.req.URL.Path, p.rec.Root)
+	if p.rec.Code == http.StatusMovedPermanently {
+		p.rw.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d", status301CacheAge))
+	}
+	p.rw.Header().Add("Status-Code", strconv.Itoa(p.rec.Code))
+	http.Redirect(p.rw, p.req, p.rec.Root, p.rec.Code)
+	if p.c.Prometheus.Enable {
+		RequestsByStatus.WithLabelValues(p.req.Host, strconv.Itoa(p.rec.Code)).Add(1)
+	}
+	return nil
+}
 
 // zoneFromPath generates a DNS zone with the given request's path and host
 // It will use custom regex to parse the path if it's provided in

--- a/path.go
+++ b/path.go
@@ -27,10 +27,9 @@ import (
 
 // Path contains the data that are needed to redirect path requests
 type Path struct {
-	rw  http.ResponseWriter
-	req *http.Request
-	c   Config
-
+	rw   http.ResponseWriter
+	req  *http.Request
+	c    Config
 	path string
 	rec  record
 }

--- a/record.go
+++ b/record.go
@@ -65,7 +65,7 @@ func getRecord(host string, c Config, w http.ResponseWriter, r *http.Request) (r
 		return rec, fmt.Errorf("could not parse record: %s", err)
 	}
 
-	r = addRecordToContext(r, rec)
+	r = rec.addToContext(r)
 
 	return rec, nil
 }
@@ -164,7 +164,7 @@ func (r *record) Parse(str string, w http.ResponseWriter, req *http.Request, c C
 }
 
 // Adds the given record to the request's context with "records" key.
-func addRecordToContext(r *http.Request, rec record) *http.Request {
+func (rec record) addToContext(r *http.Request) *http.Request {
 	// Fetch fallback config from context and add the record to it
 	recordsContext := r.Context().Value("records")
 

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -202,7 +202,8 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		RequestsCountBasedOnType.WithLabelValues(host, "proxy").Add(1)
 		log.Printf("[txtdirect]: %s > %s", rec.From, rec.To)
 
-		if err = proxyRequest(w, r, rec, c, rec.Code); err != nil {
+		proxy := NewProxy(w, r, rec, c)
+		if err = proxy.Proxy(); err != nil {
 			log.Print("Fallback is triggered because an error has occurred: ", err)
 			fallback(w, r, "to", rec.Code, c)
 		}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -128,7 +128,7 @@ func isIP(host string) bool {
 	return err == nil
 }
 
-func blacklist(w http.ResponseWriter, r *http.Request, c Config) error {
+func blacklistRedirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	if bl[r.URL.Path] {
 		redirect := strings.Join([]string{r.Host, r.URL.Path}, "")
 		log.Printf("[txtdirect]: %s > %s", r.Host+r.URL.Path, redirect)
@@ -151,7 +151,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	path := r.URL.Path
 
 	// Check the blacklist and redirect to the request's host and path
-	if err := blacklist(w, r, c); err != nil {
+	if err := blacklistRedirect(w, r, c); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves types logic to their own files and uses each type's config struct to pass data.

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Special notes for your reviewer**:
We didn't have any plans for this change but I thought it may be good to clear the main `Redirect` function a bit and move each type's logic to its own file. We can see this as a step to the plugin-based system idea that we talked about before.

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
