### PR TITLE
[gometa]: Add mod vcs and update tests

### DIFF
--- a/gometa_test.go
+++ b/gometa_test.go
@@ -38,6 +38,7 @@ func TestGometa(t *testing.T) {
 <html>
 <head>
 <meta name="go-import" content="example.com/testing git redirect.com/my-go-pkg">
+<meta name="go-import" content="example.com/testing mod https://redirect.com/my-go-pkg">
 
 </head>
 </html>`,
@@ -50,6 +51,7 @@ func TestGometa(t *testing.T) {
 <html>
 <head>
 <meta name="go-import" content="empty.com/testing git ">
+<meta name="go-import" content="empty.com/testing mod https://">
 
 </head>
 </html>`,
@@ -65,6 +67,7 @@ func TestGometa(t *testing.T) {
 <html>
 <head>
 <meta name="go-import" content="root.com/testing git redirect.com/my-root-package">
+<meta name="go-import" content="root.com/testing mod https://redirect.com/my-root-package">
 
 </head>
 </html>`,
@@ -80,6 +83,7 @@ func TestGometa(t *testing.T) {
 <html>
 <head>
 <meta name="go-import" content="root.com/testing git github.com/txtdirect/txtdirect">
+<meta name="go-import" content="root.com/testing mod https://github.com/txtdirect/txtdirect">
 <meta name="go-source" content="root.com/testing _ github.com/txtdirect/txtdirect/tree/master{/dir} github.com/txtdirect/txtdirect/blob/master{/dir}/{file}#L{line}">
 </head>
 </html>`,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds mod vcs support to gometa and updates the tests

**Which issue this PR fixes**:
fixes #283 


**Special notes for your reviewer**:
I added the protocol scheme to the mod tag because all of the tests inside the [Go's get package](https://github.com/golang/go/blob/58de7c6d4838729c6c133d9b2461dc6b1f766b76/src/cmd/go/internal/get/vcs_test.go) contain a protocol scheme. Not sure if we should add it to the git vcs tag too or not because it already works fine.
