### PR TITLE
[record]: Implement multipart record parser

### DIFF
--- a/record.go
+++ b/record.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -87,6 +88,11 @@ func (r *record) Parse(str string, w http.ResponseWriter, req *http.Request, c C
 		if err != nil {
 			return err
 		}
+
+		// Sort records based on their `p=` field
+		sort.Slice(&records, func(i, j int) bool {
+			return records[i].p < records[j].p
+		})
 
 		r.MergeRecords(records)
 

--- a/record_test.go
+++ b/record_test.go
@@ -155,6 +155,24 @@ func TestParse(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"v=txtv0;type=host;to=https://example.comp=2;to=/multipart",
+			record{
+				Version: "txtv0",
+				Type:    "host",
+				To:      "https://example.com/multipart",
+			},
+			nil,
+		},
+		{
+			"v=txtv0;type=host;to=https://example.comp=3;to=/multip=2;to=/part/sorted",
+			record{
+				Version: "txtv0",
+				Type:    "host",
+				To:      "https://example.com/part/sorted/multi",
+			},
+			nil,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements multipart record parser

**Which issue this PR fixes**:
fixes #288 


**Special notes for your reviewer**:
Would love to hear thought on other approaches for the multipart parser. I don't like the current implementation because I feel it's too complicated to read and understand.

Also for merging the records in current implementation we have to use reflections and I personally don't like using it.

Remaining parts:

- [x] Merge records
- [x] Order records based on `p=`

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
