### PR TITLE
[validator]: Add the txtdirect-validator tool

### DIFF
--- a/cmd/txtdirect-validator/main.go
+++ b/cmd/txtdirect-validator/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"go.txtdirect.org/txtdirect"
+)
+
+func main() {
+	var types string
+	var enabled []string
+
+	flag.StringVar(&types, "types", "host,path,dockerv2,gometa,proxy,git", "Enable type. Separated using commas like \"host,path,git\"")
+	flag.Parse()
+
+	enabled = strings.Split(types, ",")
+
+	config := txtdirect.Config{
+		Enable: enabled,
+	}
+
+	if len(os.Args) < 2 {
+		log.Fatalf("[txtdirect-validator]: A TXT record should be provided as a argument")
+	}
+
+	_, err := txtdirect.ParseRecord(os.Args[1], nil, &http.Request{}, config)
+	if err != nil {
+		log.Fatalf("[txtdirect-validator]: Couldn't parse the record: %s", err.Error())
+	}
+
+	log.Println("[txtdirect-validator]: The TXT record is valid.")
+}

--- a/path.go
+++ b/path.go
@@ -144,8 +144,9 @@ func (p *Path) specificMatch(regexes RegexRecords) (*record, error) {
 	// Add the most specific match's path slice to the request context to use in placeholders
 	*p.req = *p.req.WithContext(context.WithValue(p.req.Context(), "regexMatches", recordMatch[keys[len(keys)-1]].Submatches))
 
-	rec := record{}
-	if err := rec.Parse(recordMatch[keys[len(keys)-1]].TXT, p.rw, p.req, p.c); err != nil {
+	var rec record
+	var err error
+	if rec, err = ParseRecord(recordMatch[keys[len(keys)-1]].TXT, p.rw, p.req, p.c); err != nil {
 		return nil, fmt.Errorf("Could not parse record: %s", err)
 	}
 
@@ -292,8 +293,8 @@ func getFinalRecord(zone string, from int, c Config, w http.ResponseWriter, r *h
 	}
 
 	txts[0], err = parsePlaceholders(txts[0], r, pathSlice)
-	rec := record{}
-	if err = rec.Parse(txts[0], w, r, c); err != nil {
+	var rec record
+	if rec, err = ParseRecord(txts[0], w, r, c); err != nil {
 		return rec, fmt.Errorf("could not parse record: %s", err)
 	}
 

--- a/record_test.go
+++ b/record_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestParse(t *testing.T) {
+func TestParseRecord(t *testing.T) {
 	tests := []struct {
 		txtRecord string
 		expected  record
@@ -158,13 +158,13 @@ func TestParse(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		r := record{}
+		var r record
 		c := Config{
 			Enable: []string{test.expected.Type},
 		}
 		req, _ := http.NewRequest("GET", "http://example.com?url=https://example.com/testing", nil)
 		w := httptest.NewRecorder()
-		err := r.Parse(test.txtRecord, w, req, c)
+		r, err := ParseRecord(test.txtRecord, w, req, c)
 
 		if err != nil {
 			if test.err == nil || !strings.HasPrefix(err.Error(), test.err.Error()) {

--- a/setup.go
+++ b/setup.go
@@ -44,7 +44,7 @@ func init() {
 
 var allOptions = []string{"host", "path", "gometa", "www"}
 
-func parse(c *caddy.Controller) (Config, error) {
+func ParseConfig(c *caddy.Controller) (Config, error) {
 	var enable []string
 	var redirect string
 	var resolver string
@@ -160,7 +160,7 @@ func parse(c *caddy.Controller) (Config, error) {
 }
 
 func setup(c *caddy.Controller) error {
-	config, err := parse(c)
+	config, err := ParseConfig(c)
 	if err != nil {
 		return err
 	}

--- a/setup_test.go
+++ b/setup_test.go
@@ -300,7 +300,7 @@ func TestCaddyParse(t *testing.T) {
 	for i, test := range tests {
 		log.Println(log.Flags())
 		c := caddy.NewTestController("http", test.input)
-		conf, err := parse(c)
+		conf, err := ParseConfig(c)
 		if !test.shouldErr && err != nil {
 			t.Errorf("Test %d: Unexpected error %s", i, err)
 			continue


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes the record parser and adds the validator tool

**Which issue this PR fixes**:
fixes #263 


**Special notes for your reviewer**:
The features that might be good to have:
* A flag to pass a URI and use it for parsing the placeholders inside the record
* A flag to pass a config file and use it to parse a complete config (Right now it only lets the user customize enabled types).

**Release note**:
`nil`