### PR TITLE
[prometheus]: Fix startup and register bug

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -95,20 +95,18 @@ func (p *Prometheus) SetDefaults() {
 }
 
 func (p *Prometheus) start() error {
-	once.Do(func() {
-		prometheus.MustRegister(RequestsCount)
-		prometheus.MustRegister(RequestsByStatus)
-		prometheus.MustRegister(RequestsCountBasedOnType)
-		prometheus.MustRegister(FallbacksCount)
-		prometheus.MustRegister(PathRedirectCount)
-		http.Handle(p.Path, p.handler)
-		go func() {
-			err := http.ListenAndServe(p.Address, nil)
-			if err != nil {
-				log.Printf("[txtdirect]: Couldn't start http handler for prometheus metrics. %s", err.Error())
-			}
-		}()
-	})
+	prometheus.MustRegister(RequestsCount)
+	prometheus.MustRegister(RequestsByStatus)
+	prometheus.MustRegister(RequestsCountBasedOnType)
+	prometheus.MustRegister(FallbacksCount)
+	prometheus.MustRegister(PathRedirectCount)
+	http.Handle(p.Path, p.handler)
+	go func() {
+		err := http.ListenAndServe(p.Address, nil)
+		if err != nil {
+			log.Printf("[txtdirect]: Couldn't start http handler for prometheus metrics. %s", err.Error())
+		}
+	}()
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes startup and register bug

**Which issue this PR fixes**:
fixes #306 


**Special notes for your reviewer**:
We didn't need to call `once` twice, the Prometheus `start` function already did run once on the startup.

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
