### PR TITLE
[headers]: Add custom headers using records

### DIFF
--- a/record.go
+++ b/record.go
@@ -34,6 +34,7 @@ type record struct {
 	Root    string
 	Re      string
 	Ref     bool
+	Headers map[string]string
 }
 
 // getRecord uses the given host to find a TXT record
@@ -71,12 +72,15 @@ func getRecord(host string, c Config, w http.ResponseWriter, r *http.Request) (r
 	return rec, nil
 }
 
-// Parse takes a string containing the DNS TXT record and returns
+// ParseRecord takes a string containing the DNS TXT record and returns
 // a TXTDirect record struct instance.
 // It will return an error if the DNS TXT record is not standard or
 // if the record type is not enabled in the TXTDirect's config.
 func ParseRecord(str string, w http.ResponseWriter, req *http.Request, c Config) (record, error) {
-	r := record{}
+	r := record{
+		Headers: map[string]string{},
+	}
+
 	s := strings.Split(str, ";")
 	for _, l := range s {
 		switch {
@@ -142,6 +146,9 @@ func ParseRecord(str string, w http.ResponseWriter, req *http.Request, c Config)
 			l = strings.TrimPrefix(l, "website=")
 			l = ParseURI(l, w, req, c)
 			r.Website = l
+		case strings.HasPrefix(l, ">"):
+			header := strings.Split(l, "=")
+			r.Headers[header[0][1:]] = header[1]
 
 		default:
 			tuple := strings.Split(l, "=")

--- a/record.go
+++ b/record.go
@@ -69,6 +69,13 @@ func getRecord(host string, c Config, w http.ResponseWriter, r *http.Request) (r
 
 	r = rec.addToContext(r)
 
+	// Add the headers from record to the response
+	if len(rec.Headers) != 0 {
+		for header, val := range rec.Headers {
+			w.Header().Set(header, val)
+		}
+	}
+
 	return rec, nil
 }
 

--- a/record_test.go
+++ b/record_test.go
@@ -156,6 +156,29 @@ func TestParseRecord(t *testing.T) {
 			},
 			status: 404,
 		},
+		{
+			txtRecord: "v=txtv0;type=path;code=302;>Header-1=HeaderValue",
+			expected: record{
+				Version: "txtv0",
+				Type:    "path",
+				Code:    302,
+				Ref:     false,
+				Headers: map[string]string{"Header-1": "HeaderValue"},
+			},
+		},
+		{
+			txtRecord: "v=txtv0;type=path;code=302;>Header-1=HeaderValue;>Header-2=HeaderValue",
+			expected: record{
+				Version: "txtv0",
+				Type:    "path",
+				Code:    302,
+				Ref:     false,
+				Headers: map[string]string{
+					"Header-1": "HeaderValue",
+					"Header-2": "HeaderValue",
+				},
+			},
+		},
 	}
 
 	for i, test := range tests {
@@ -199,6 +222,17 @@ func TestParseRecord(t *testing.T) {
 		}
 		if got, want := r.Vcs, test.expected.Vcs; got != want {
 			t.Errorf("Test %d: Expected Vcs to be '%s', got '%s'", i, want, got)
+		}
+
+		if len(r.Headers) != len(test.expected.Headers) {
+			t.Errorf("Test %d: Expected %d headers, got '%d'", i, len(r.Headers), len(test.expected.Headers))
+		}
+
+		for header, val := range r.Headers {
+			if test.expected.Headers[header] != val {
+				t.Errorf("Test %d: Expected %s Header to be '%s', got '%s'",
+					i, header, test.expected.Headers[header], val)
+			}
 		}
 	}
 }

--- a/txtdirect_test.go
+++ b/txtdirect_test.go
@@ -474,6 +474,10 @@ func TestRecordHeadersE2E(t *testing.T) {
 				"TestHeader1": "TestValue1",
 			},
 		},
+		{
+			"https://host.host.example.com",
+			map[string]string{"testheader": "TestValue"},
+		},
 	}
 	for _, test := range tests {
 		req := httptest.NewRequest("GET", test.url, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements the feature to add custom headers using TXT records.


**Which issue this PR fixes**:
fixes #308 


**Special notes for your reviewer**:
Nan

**Release note**:

*Note: All the header values should be percent-encoded.*

Example for single record:
```
"_redirect.example.com.": "v=txtv0;to=https://example.com;type=host;>TestHeader=TestValue;code=302"
```

Example for chained records using path type:
```
"_redirect.path.example.com.": "v=txtv0;type=path;>TestHeader=TestValue;>TestHeader1=TestValue1"
"_redirect.child.path.example.com.": "v=txtv0;type=host;to=https://example.com;"
```

HSTS Example:
```
"_redirect.example.com.": "v=txtv0;to=https://example.com;type=host;>Strict-Transport-Security=max-age%3D63072000%3B+includeSubDomains%3B+preload+;code=302"
```
