### PR TITLE
(path): Stop adding query to path by default

### DIFF
--- a/path.go
+++ b/path.go
@@ -197,7 +197,12 @@ func zoneFromPath(r *http.Request, rec record) (string, int, []string, error) {
 		path = path[:strings.Index(path, "/info/refs")]
 	}
 
-	path = fmt.Sprintf("%s?%s", path, r.URL.RawQuery)
+	// Only add request query to path if the custom regex needs it. Unless it
+	// might cause problems on custom regexes that don't need query to generate
+	// the zone
+	if strings.Contains(rec.Re, "query") {
+		path = fmt.Sprintf("%s?%s", path, r.URL.RawQuery)
+	}
 
 	pathSubmatchs := PathRegex.FindAllStringSubmatch(path, -1)
 	if rec.Re != "" {
@@ -210,7 +215,6 @@ func zoneFromPath(r *http.Request, rec record) (string, int, []string, error) {
 
 		// Only generate the zone if the custom regex contains a group
 		if GroupRegex.MatchString(rec.Re) {
-			//
 			pathSlice := []string{}
 			unordered := make(map[string]string)
 			for _, item := range pathSubmatchs[0] {

--- a/path.go
+++ b/path.go
@@ -200,7 +200,7 @@ func zoneFromPath(r *http.Request, rec record) (string, int, []string, error) {
 	// Only add request query to path if the custom regex needs it. Unless it
 	// might cause problems on custom regexes that don't need query to generate
 	// the zone
-	if strings.Contains(rec.Re, "query") {
+	if strings.Contains(rec.Re, "?query") {
 		path = fmt.Sprintf("%s?%s", path, r.URL.RawQuery)
 	}
 

--- a/path_test.go
+++ b/path_test.go
@@ -162,8 +162,11 @@ func Test_zoneFromPath(t *testing.T) {
 		zone, _, _, err := zoneFromPath(req, rec)
 		if err != nil {
 			// Check negative tests
-			if err.Error() == test.err.Error() {
-				continue
+			if test.err != nil {
+				if err.Error() == test.err.Error() {
+					continue
+				}
+				t.Errorf("Expected %s, got %s", test.err.Error(), err.Error())
 			}
 			t.Errorf("Got error: %s", err.Error())
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
If the custom regex doesn't need the request query and we add it by default, it will cause some problems and generate a wrong zone address. Fixed this issue by only adding the request query when a custom regex needs it.

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
