### PR TITLE
[record]: Add `use=` field

### DIFF
--- a/e2e/host/main.go
+++ b/e2e/host/main.go
@@ -79,6 +79,14 @@ var tests = []test{
 		},
 		expected: "https://upstream.host.host.example.com",
 	},
+	{
+		name: "Redirect using the upstream record and ignore the source record's to= field",
+		args: data{
+			host: "sourcerecord.host.host.example.com",
+			path: "/",
+		},
+		expected: "https://upstream.host.host.example.com",
+	},
 }
 
 func main() {

--- a/e2e/host/main.go
+++ b/e2e/host/main.go
@@ -71,6 +71,14 @@ var tests = []test{
 		},
 		status: 404,
 	},
+	{
+		name: "Redirect using the use= field and upstream record",
+		args: data{
+			host: "sourcerecord.host.host.example.com",
+			path: "/",
+		},
+		expected: "https://upstream.host.host.example.com",
+	},
 }
 
 func main() {

--- a/e2e/host/zonefile
+++ b/e2e/host/zonefile
@@ -10,24 +10,29 @@
 
 $TTL 1h
 
-example.com.                IN A 172.20.10.2
+example.com.                                     IN A 172.20.10.2
 
 ; Host records
 
-to.host.host.example.com.         IN A 172.20.10.2
-_redirect.to.host.host.example.com.          IN TXT "v=txtv0;to=https://to-redirect.host.host.example.com;type=host;code=302" 
+to.host.host.example.com.                        IN A 172.20.10.2
+_redirect.to.host.host.example.com.              IN TXT "v=txtv0;to=https://to-redirect.host.host.example.com;type=host;code=302" 
 
-nocode.host.host.example.com.    IN A 172.20.10.2
-_redirect.nocode.host.host.example.com.      IN TXT "v=txtv0;to=https://nocode.host.host.example.com;type=host"
+nocode.host.host.example.com.                    IN A 172.20.10.2
+_redirect.nocode.host.host.example.com.          IN TXT "v=txtv0;to=https://nocode.host.host.example.com;type=host"
 
-noversion.host.host.example.com. IN A 172.20.10.2
-_redirect.noversion.host.host.example.com.   IN TXT "to=https://noversion.host.host.example.com;type=host"
+noversion.host.host.example.com.                 IN A 172.20.10.2
+_redirect.noversion.host.host.example.com.       IN TXT "to=https://noversion.host.host.example.com;type=host"
 
-noto.host.host.example.com.      IN A 172.20.10.2
-_redirect.noto.host.host.example.com.        IN TXT "v=txtv0;type=host"
+noto.host.host.example.com.                      IN A 172.20.10.2
+_redirect.noto.host.host.example.com.            IN TXT "v=txtv0;type=host"
 
-referer.host.host.example.com.   IN A 172.20.10.2
-_redirect.referer.host.host.example.com.     IN TXT "to=https://referer-redirect.host.host.example.com;type=host;ref=true"
+referer.host.host.example.com.                   IN A 172.20.10.2
+_redirect.referer.host.host.example.com.         IN TXT "to=https://referer-redirect.host.host.example.com;type=host;ref=true"
 
-fallback.host.host.example.com.              IN A 172.20.10.2
-_redirect.fallback.host.host.example.com.    IN TXT "v=txtv0;to=https://{label30};type=host;code=302" 
+fallback.host.host.example.com.                  IN A 172.20.10.2
+_redirect.fallback.host.host.example.com.        IN TXT "v=txtv0;to=https://{label30};type=host;code=302" 
+
+sourcerecord.host.host.example.com.              IN A 172.20.10.2
+upstreamrecord.host.host.example.com.            IN A 172.20.10.2
+_redirect.sourcerecord.host.host.example.com.    IN TXT "v=txtv0;to=https://wrongredirect.host.host.example.com;type=host;code=302;use=_redirect.upstreamrecord.host.host.example.com" 
+_redirect.upstreamrecord.host.host.example.com.  IN TXT "v=txtv0;to=https://upstream.host.host.example.com;type=host;code=302" 

--- a/e2e/host/zonefile
+++ b/e2e/host/zonefile
@@ -34,5 +34,11 @@ _redirect.fallback.host.host.example.com.        IN TXT "v=txtv0;to=https://{lab
 
 sourcerecord.host.host.example.com.              IN A 172.20.10.2
 upstreamrecord.host.host.example.com.            IN A 172.20.10.2
-_redirect.sourcerecord.host.host.example.com.    IN TXT "v=txtv0;to=https://wrongredirect.host.host.example.com;type=host;code=302;use=_redirect.upstreamrecord.host.host.example.com" 
+_redirect.sourcerecord.host.host.example.com.    IN TXT "v=txtv0;type=host;use=_redirect.upstreamrecord.host.host.example.com" 
 _redirect.upstreamrecord.host.host.example.com.  IN TXT "v=txtv0;to=https://upstream.host.host.example.com;type=host;code=302" 
+
+
+srcwithto.host.host.example.com.              IN A 172.20.10.2
+uprecord.host.host.example.com.               IN A 172.20.10.2
+_redirect.srcwithto.host.host.example.com.    IN TXT "v=txtv0;to=https://wrongredirect.host.host.example.com;type=host;code=302;use=_redirect.upstreamrecord.host.host.example.com" 
+_redirect.uprecord.host.host.example.com.     IN TXT "v=txtv0;to=https://upstream.host.host.example.com;type=host;code=302" 

--- a/e2e/main.go
+++ b/e2e/main.go
@@ -177,16 +177,6 @@ func (d *dockerManager) StartContainers() error {
 }
 
 func (d *dockerManager) StopContainers() error {
-	if strings.Contains(d.dir, "path") {
-		logs, err := exec.Command("docker",
-			"logs",
-			"e2e_txtdirect_container",
-		).CombinedOutput()
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(logs))
-	}
 	_, err := exec.Command("docker",
 		"container", "rm", "-f",
 		"e2e_coredns_container",

--- a/e2e/main.go
+++ b/e2e/main.go
@@ -177,14 +177,15 @@ func (d *dockerManager) StartContainers() error {
 }
 
 func (d *dockerManager) StopContainers() error {
-	if strings.Contains(d.dir, "dockerv2") {
-		_, err := exec.Command("docker",
+	if strings.Contains(d.dir, "path") {
+		logs, err := exec.Command("docker",
 			"logs",
 			"e2e_txtdirect_container",
 		).CombinedOutput()
 		if err != nil {
 			return err
 		}
+		fmt.Println(string(logs))
 	}
 	_, err := exec.Command("docker",
 		"container", "rm", "-f",

--- a/e2e/path/main.go
+++ b/e2e/path/main.go
@@ -82,6 +82,14 @@ var tests = []test{
 		},
 		expected: "https://upstream.path.path.example.com",
 	},
+	{
+		name: "Redirect to upstream record using multiple use= fields",
+		args: data{
+			host: "srcrecord.path.path.example.com",
+			path: "/testing",
+		},
+		expected: "https://upstream.path.path.example.com",
+	},
 }
 
 func main() {

--- a/e2e/path/main.go
+++ b/e2e/path/main.go
@@ -15,6 +15,8 @@ type test struct {
 	name     string
 	args     data
 	expected string
+	fallback bool
+	status   int
 }
 
 var tests = []test{
@@ -56,6 +58,7 @@ var tests = []test{
 			host: "path.path.example.com",
 			path: "/not/found",
 		},
+		fallback: true,
 		expected: "https://fallback-to.path.path.example.com",
 	},
 	{
@@ -64,6 +67,7 @@ var tests = []test{
 			host: "fallback-refrom.path.path.example.com",
 			path: "/",
 		},
+		fallback: true,
 		expected: "https://fallback-to.path.path.example.com",
 	},
 	{
@@ -72,6 +76,7 @@ var tests = []test{
 			host: "fallback-lenfrom.path.path.example.com",
 			path: "/",
 		},
+		fallback: true,
 		expected: "https://fallback-to.path.path.example.com",
 	},
 	{
@@ -83,12 +88,21 @@ var tests = []test{
 		expected: "https://upstream.path.path.example.com",
 	},
 	{
-		name: "Redirect to upstream record using multiple use= fields",
+		name: "Redirect to upstream record using multiple use= fields and skipping non-working upstream",
 		args: data{
 			host: "srcrecord.path.path.example.com",
 			path: "/testing",
 		},
 		expected: "https://upstream.path.path.example.com",
+	},
+	{
+		name: "Fallback when the upstream record doesn't respond",
+		args: data{
+			host: "fallbackupstream.path.path.example.com",
+			path: "/testing",
+		},
+		fallback: true,
+		status:   404,
 	},
 }
 
@@ -106,6 +120,17 @@ func main() {
 		if err != nil {
 			result[false] = append(result[false], test)
 			log.Printf("[%s]: Couldn't send the request: %s", test.name, err.Error())
+			continue
+		}
+
+		// Check response's status code
+		if test.status != 0 {
+			if resp.StatusCode != test.status {
+				result[false] = append(result[false], test)
+				log.Printf("[%s]: Expected %d status code, got %d", test.name, test.status, resp.StatusCode)
+				continue
+			}
+			result[true] = append(result[true], test)
 			continue
 		}
 

--- a/e2e/path/main.go
+++ b/e2e/path/main.go
@@ -74,6 +74,14 @@ var tests = []test{
 		},
 		expected: "https://fallback-to.path.path.example.com",
 	},
+	{
+		name: "Redirect using the use= field and upstream record",
+		args: data{
+			host: "sourcerecord.path.path.example.com",
+			path: "/testing",
+		},
+		expected: "https://upstream.path.path.example.com",
+	},
 }
 
 func main() {

--- a/e2e/path/zonefile
+++ b/e2e/path/zonefile
@@ -36,3 +36,9 @@ _redirect.fallback-refrom.path.path.example.com.       IN TXT "v=txtv0;type=path
 
 fallback-lenfrom.path.path.example.com.                IN A 172.20.10.2
 _redirect.fallback-lenfrom.path.path.example.com.      IN TXT "v=txtv0;type=path;from=$1$2$3;to=https://fallback-to.path.path.example.com;code=302"
+
+sourcerecord.path.path.example.com.                    IN A 172.20.10.2
+upstreamrecord.path.path.example.com.                  IN A 172.20.10.2
+_redirect.sourcerecord.path.path.example.com.          IN TXT "v=txtv0;type=path;use=_redirect.upstreamrecord.path.path.example.com"
+_redirect.upstreamrecord.path.path.example.com.        IN TXT "v=txtv0;type=path"
+_redirect._.upstreamrecord.path.path.example.com.      IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 

--- a/e2e/path/zonefile
+++ b/e2e/path/zonefile
@@ -42,3 +42,9 @@ upstreamrecord.path.path.example.com.                  IN A 172.20.10.2
 _redirect.sourcerecord.path.path.example.com.          IN TXT "v=txtv0;type=path;use=_redirect.upstreamrecord.path.path.example.com"
 _redirect.upstreamrecord.path.path.example.com.        IN TXT "v=txtv0;type=path"
 _redirect._.upstreamrecord.path.path.example.com.      IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 
+
+srcrecord.path.path.example.com.                       IN A 172.20.10.2
+uprecord.path.path.example.com.                        IN A 172.20.10.2
+_redirect.srcrecord.path.path.example.com.             IN TXT "v=txtv0;type=path;use=_redirect.wrongupstream.path.path.example.com;use=_redirect.uprecord.path.path.example.com"
+_redirect.uprecord.path.path.example.com.              IN TXT "v=txtv0;type=path"
+_redirect._.uprecord.path.path.example.com.            IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 

--- a/e2e/path/zonefile
+++ b/e2e/path/zonefile
@@ -48,3 +48,7 @@ uprecord.path.path.example.com.                        IN A 172.20.10.2
 _redirect.srcrecord.path.path.example.com.             IN TXT "v=txtv0;type=path;use=_redirect.wrongupstream.path.path.example.com;use=_redirect.uprecord.path.path.example.com"
 _redirect.uprecord.path.path.example.com.              IN TXT "v=txtv0;type=path"
 _redirect._.uprecord.path.path.example.com.            IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 
+
+
+fallbackupstream.path.path.example.com.                IN A 172.20.10.2
+_redirect.fallbackupstream.path.path.example.com.      IN TXT "v=txtv0;type=path;use=_redirect.wrongupstream.path.path.example.com"

--- a/record.go
+++ b/record.go
@@ -28,6 +28,7 @@ type record struct {
 	To      string
 	Code    int
 	Type    string
+	Use     []string
 	Vcs     string
 	Website string
 	From    string
@@ -142,6 +143,13 @@ func ParseRecord(str string, w http.ResponseWriter, req *http.Request, c Config)
 		case strings.HasPrefix(l, "type="):
 			l = strings.TrimPrefix(l, "type=")
 			r.Type = l
+
+		case strings.HasPrefix(l, "use="):
+			l = strings.TrimPrefix(l, "use=")
+			if !strings.HasPrefix(l, "_redirect.") {
+				return record{}, fmt.Errorf("The given zone address is invalid")
+			}
+			r.Use = append(r.Use, l)
 
 		case strings.HasPrefix(l, "v="):
 			l = strings.TrimPrefix(l, "v=")

--- a/record.go
+++ b/record.go
@@ -193,17 +193,20 @@ func ParseRecord(str string, w http.ResponseWriter, req *http.Request, c Config)
 		r.Code = http.StatusFound
 	}
 
-	if r.Type == "" {
-		r.Type = "host"
-	}
+	// Only apply rules and default to records that doesn't point to a upstream record
+	if len(r.Use) == 0 {
+		if r.Type == "" {
+			r.Type = "host"
+		}
 
-	if r.Type == "host" && r.To == "" {
-		fallback(w, req, "global", http.StatusMovedPermanently, c)
-		return record{}, nil
-	}
+		if r.Type == "host" && r.To == "" {
+			fallback(w, req, "global", http.StatusMovedPermanently, c)
+			return record{}, nil
+		}
 
-	if !contains(c.Enable, r.Type) {
-		return record{}, fmt.Errorf("%s type is not enabled in configuration", r.Type)
+		if !contains(c.Enable, r.Type) {
+			return record{}, fmt.Errorf("%s type is not enabled in configuration", r.Type)
+		}
 	}
 
 	return r, nil

--- a/record.go
+++ b/record.go
@@ -77,13 +77,6 @@ func getRecord(host string, c Config, w http.ResponseWriter, r *http.Request) (r
 		}
 	}
 
-	if len(rec.Use) != 0 {
-		rec, err = rec.ReplaceRecord(c, w, r)
-		if err != nil {
-			return record{}, fmt.Errorf("Couldn't replace the record: %s", err.Error())
-		}
-	}
-
 	return rec, nil
 }
 
@@ -242,19 +235,21 @@ func ParseURI(uri string, w http.ResponseWriter, r *http.Request, c Config) stri
 	return url.String()
 }
 
-// ReplaceRecord will check all of the use= fields and sends a request to each
+// UpstreamRecord will check all of the use= fields and sends a request to each
 // upstream zone address and choses the first one that returns the final TXT
 // record
-func (rec *record) ReplaceRecord(c Config, w http.ResponseWriter, r *http.Request) (record, error) {
+func (rec *record) UpstreamRecord(c Config, w http.ResponseWriter, r *http.Request) (record, string, error) {
 	var upstreamRec record
 	var err error
 
+	// TODO: Check all the zones then return an error if no record found
 	for _, zone := range rec.Use {
 		upstreamRec, err = getRecord(zone, c, w, r)
 		if err != nil {
-			return record{}, fmt.Errorf("Couldn't query the upstream record: %s", err.Error())
+			return record{}, zone, fmt.Errorf("Couldn't query the upstream record: %s", err.Error())
 		}
+		return upstreamRec, zone, nil
 	}
 
-	return upstreamRec, nil
+	return record{}, "", fmt.Errorf("Couldn't find any records from upstream")
 }

--- a/record.go
+++ b/record.go
@@ -242,11 +242,10 @@ func (rec *record) UpstreamRecord(c Config, w http.ResponseWriter, r *http.Reque
 	var upstreamRec record
 	var err error
 
-	// TODO: Check all the zones then return an error if no record found
 	for _, zone := range rec.Use {
 		upstreamRec, err = getRecord(zone, c, w, r)
 		if err != nil {
-			return record{}, zone, fmt.Errorf("Couldn't query the upstream record: %s", err.Error())
+			continue
 		}
 		return upstreamRec, zone, nil
 	}

--- a/record_test.go
+++ b/record_test.go
@@ -180,6 +180,28 @@ func TestParseRecord(t *testing.T) {
 			},
 		},
 		{
+			txtRecord: "v=txtv0;type=host;to=https://example.com;code=302;use=_redirect.example.com",
+			expected: record{
+				Version: "txtv0",
+				Type:    "host",
+				Code:    302,
+				Ref:     false,
+				To:      "https://example.com",
+				Use:     []string{"_redirect.example.com"},
+			},
+		},
+		{
+			txtRecord: "v=txtv0;type=host;to=https://example.com;use=_redirect.example.com;use=_redirect.example2.com",
+			expected: record{
+				Version: "txtv0",
+				Type:    "host",
+				Code:    302,
+				Ref:     false,
+				To:      "https://example.com",
+				Use:     []string{"_redirect.example.com", "_redirect.example2.com"},
+			},
+		},
+		{
 			// Commonly used http headers used for better real world testing.
 			// Taken from: https://www.whitehatsec.com/blog/list-of-http-response-headers/
 			txtRecord: `v=txtv0;type=path;code=302;
@@ -365,6 +387,13 @@ func TestParseRecord(t *testing.T) {
 			if test.expected.Headers[header] != val {
 				t.Errorf("Test %d: Expected %s Header to be '%s', got '%s'",
 					i, header, test.expected.Headers[header], val)
+			}
+		}
+
+		for i, zone := range r.Use {
+			if test.expected.Use[i] != zone {
+				t.Errorf("Test %d: Expected zone address to be '%s', got '%s'",
+					i, test.expected.Use[i], zone)
 			}
 		}
 	}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -186,12 +186,13 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 	}
 
 	// Add the upstream zone address from the use= fields to the request context
-	// and replace the source record with the upstream record
 	if len(rec.Use) != 0 {
 		var zone string
 		rec, zone, err = rec.UpstreamRecord(c, w, r)
 		if err != nil {
-			return fmt.Errorf("Couldn't replace the record: %s", err.Error())
+			log.Printf("[txtdirect]: Couldn't fetch the upstream record: %s", err.Error())
+			fallback(w, r, "global", http.StatusFound, c)
+			return nil
 		}
 
 		zoneSplited := strings.Split(zone, ".")


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the `use=` field to record to provide a feature like how CNAME records work. The `use=` field can be used to redirect a TXT record request to another upstream zone. Basically use a TXT record that has been specified for another zone address.

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Special notes for your reviewer**:
~~Still trying to figure out how to fix the bugs on the `path` type, so not ready for a full review.~~

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
