### PR TITLE
[E2E]: Fix predefined regex bugs and add E2E tests

### DIFF
--- a/e2e/gometa/main.go
+++ b/e2e/gometa/main.go
@@ -17,6 +17,7 @@ type test struct {
 	name     string
 	args     data
 	expected string
+	comment  string
 }
 
 var tests = []test{
@@ -52,6 +53,42 @@ var tests = []test{
 		},
 		expected: "https://fallback-to.gometa.path.example.com",
 	},
+	{
+		name: "Fallback to path record's \"to=\" when path is empty",
+		args: data{
+			host: "custom-regex.gometa.path.example.com",
+			path: "/",
+		},
+		expected: "https://no-path.gometa.path.example.com/",
+		comment:  "for: k8s.io",
+	},
+	{
+		name: "Redirect to gometa record using the custom regex in path record",
+		args: data{
+			host: "custom-regex.gometa.path.example.com",
+			path: "/txtdirect/txtdirect?go-get=1",
+		},
+		expected: "https://package.gometa.path.example.com/txtdirect",
+		comment:  "for: k8s.io",
+	},
+	{
+		name: "Redirect to gometa record using the custom regex and single path",
+		args: data{
+			host: "custom-regex.gometa.path.example.com",
+			path: "/txtdirect?go-get=1",
+		},
+		expected: "https://package.gometa.path.example.com/txtdirect",
+		comment:  "for: k8s.io",
+	},
+	// {
+	// 	name: "Redirect to host record if request doesn't have ?go-get=1",
+	// 	args: data{
+	// 		host: "repo-and-package.gometa.path.example.com",
+	// 		path: "/txtdirect",
+	// 	},
+	// 	expected: "https://nongoget.gometa.path.example.com/txtdirect",
+	//  comment: "sigs.k8s.io",
+	// },
 }
 
 func main() {
@@ -64,6 +101,7 @@ func main() {
 		}
 
 		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s%s", test.args.host, test.args.path), nil)
+		req.URL.EscapedPath()
 		resp, err := client.Do(req)
 		if err != nil {
 			result[false] = append(result[false], test)

--- a/e2e/gometa/zonefile
+++ b/e2e/gometa/zonefile
@@ -20,9 +20,19 @@ _redirect.path.example.com.                    IN TXT "v=txtv0;type=path"
 _redirect.gometa.path.example.com.             IN TXT "v=txtv0;to=https://gometa-redirect.gometa.path.example.com/golang/package;type=gometa"
 _redirect.multiple.gometa.path.example.com.    IN TXT "v=txtv0;to=https://gometa-redirect.gometa.path.example.com/second/golang/package;type=gometa"
 
-fallback.gometa.path.example.com.                       IN A 172.20.10.2
-_redirect.fallback.gometa.path.example.com.             IN TXT "v=txtv0;type=path;to=https://fallback-to.gometa.path.example.com"
+fallback.gometa.path.example.com.              IN A 172.20.10.2
+_redirect.fallback.gometa.path.example.com.    IN TXT "v=txtv0;type=path;to=https://fallback-to.gometa.path.example.com"
 
-fallback-empty-to.gometa.path.example.com.   IN A 172.20.10.2
-_redirect.empty-to.gometa.path.example.com.  IN TXT "v=txtv0;to=wrong:/url.test;type=gometa"
+fallback-empty-to.gometa.path.example.com.     IN A 172.20.10.2
+_redirect.empty-to.gometa.path.example.com.    IN TXT "v=txtv0;to=wrong:/url.test;type=gometa"
 
+custom-regex.gometa.path.example.com.          IN A   172.20.10.2
+_redirect.custom-regex.gometa.path.example.com.                            IN TXT "v=txtv0;type=path;root=https://no-path.gometa.path.example.com{uri};re=^/(?P<repo>[^/]*)(?P<subpath>/.*)?$"
+_redirect._._.custom-regex.gometa.path.example.com.                        IN TXT "v=txtv0;type=gometa;to=https://package.gometa.path.example.com/{repo}"
+
+
+; repo-and-package.gometa.path.example.com.                            IN A   172.20.10.2
+
+; _redirect.repo-and-package.gometa.path.example.com.                  IN TXT "v=txtv0;type=path;code=301;to=https://default.gometa.path.example.com/{sig_repo}/{repo_subpath};re=^/(?P<sig_repo>.*?)(?!/+$)(?P<repo_subpath>/.*)?$"
+; _redirect._.repo-and-package.gometa.path.example.com.                IN TXT "v=txtv0;type=host;code=301;to=https://nongoget.gometa.path.example.com/{sig_repo}"
+; _redirect._._.repo-and-package.gometa.path.example.com.              IN TXT "v=txtv0;type=gometa;to=https://github.com/kubernetes-sigs/{sig_repo}"

--- a/e2e/host/main.go
+++ b/e2e/host/main.go
@@ -71,6 +71,14 @@ var tests = []test{
 		},
 		status: 404,
 	},
+	{
+		name: "Redirect using the use= field and upstream record",
+		args: data{
+			host: "sourcerecord.host.host.example.com",
+			path: "/",
+		},
+		expected: "https://upstream.host.host.example.com",
+	},
 }
 
 func main() {

--- a/e2e/host/zonefile
+++ b/e2e/host/zonefile
@@ -10,24 +10,29 @@
 
 $TTL 1h
 
-example.com.                IN A 172.20.10.2
+example.com.                                     IN A 172.20.10.2
 
 ; Host records
 
-to.host.host.example.com.         IN A 172.20.10.2
-_redirect.to.host.host.example.com.          IN TXT "v=txtv0;to=https://to-redirect.host.host.example.com;type=host;code=302" 
+to.host.host.example.com.                        IN A 172.20.10.2
+_redirect.to.host.host.example.com.              IN TXT "v=txtv0;to=https://to-redirect.host.host.example.com;type=host;code=302" 
 
-nocode.host.host.example.com.    IN A 172.20.10.2
-_redirect.nocode.host.host.example.com.      IN TXT "v=txtv0;to=https://nocode.host.host.example.com;type=host"
+nocode.host.host.example.com.                    IN A 172.20.10.2
+_redirect.nocode.host.host.example.com.          IN TXT "v=txtv0;to=https://nocode.host.host.example.com;type=host"
 
-noversion.host.host.example.com. IN A 172.20.10.2
-_redirect.noversion.host.host.example.com.   IN TXT "to=https://noversion.host.host.example.com;type=host"
+noversion.host.host.example.com.                 IN A 172.20.10.2
+_redirect.noversion.host.host.example.com.       IN TXT "to=https://noversion.host.host.example.com;type=host"
 
-noto.host.host.example.com.      IN A 172.20.10.2
-_redirect.noto.host.host.example.com.        IN TXT "v=txtv0;type=host"
+noto.host.host.example.com.                      IN A 172.20.10.2
+_redirect.noto.host.host.example.com.            IN TXT "v=txtv0;type=host"
 
-referer.host.host.example.com.   IN A 172.20.10.2
-_redirect.referer.host.host.example.com.     IN TXT "to=https://referer-redirect.host.host.example.com;type=host;ref=true"
+referer.host.host.example.com.                   IN A 172.20.10.2
+_redirect.referer.host.host.example.com.         IN TXT "to=https://referer-redirect.host.host.example.com;type=host;ref=true"
 
-fallback.host.host.example.com.              IN A 172.20.10.2
-_redirect.fallback.host.host.example.com.    IN TXT "v=txtv0;to=https://{label30};type=host;code=302" 
+fallback.host.host.example.com.                  IN A 172.20.10.2
+_redirect.fallback.host.host.example.com.        IN TXT "v=txtv0;to=https://{label30};type=host;code=302" 
+
+sourcerecord.host.host.example.com.              IN A 172.20.10.2
+upstreamrecord.host.host.example.com.            IN A 172.20.10.2
+_redirect.sourcerecord.host.host.example.com.    IN TXT "v=txtv0;to=https://wrongredirect.host.host.example.com;type=host;code=302;use=_redirect.upstreamrecord.host.host.example.com" 
+_redirect.upstreamrecord.host.host.example.com.  IN TXT "v=txtv0;to=https://upstream.host.host.example.com;type=host;code=302" 

--- a/e2e/main.go
+++ b/e2e/main.go
@@ -177,14 +177,15 @@ func (d *dockerManager) StartContainers() error {
 }
 
 func (d *dockerManager) StopContainers() error {
-	if strings.Contains(d.dir, "dockerv2") {
-		_, err := exec.Command("docker",
+	if strings.Contains(d.dir, "path") {
+		logs, err := exec.Command("docker",
 			"logs",
 			"e2e_txtdirect_container",
 		).CombinedOutput()
 		if err != nil {
 			return err
 		}
+		fmt.Println(string(logs))
 	}
 	_, err := exec.Command("docker",
 		"container", "rm", "-f",

--- a/e2e/path/main.go
+++ b/e2e/path/main.go
@@ -82,6 +82,14 @@ var tests = []test{
 		},
 		expected: "https://upstream.path.path.example.com",
 	},
+	{
+		name: "Redirect to upstream record using multiple use= fields",
+		args: data{
+			host: "srcrecord.path.path.example.com",
+			path: "/testing",
+		},
+		expected: "https://upstream.path.path.example.com",
+	},
 }
 
 func main() {

--- a/e2e/path/main.go
+++ b/e2e/path/main.go
@@ -15,6 +15,7 @@ type test struct {
 	name     string
 	args     data
 	expected string
+	comment  string
 }
 
 var tests = []test{
@@ -40,7 +41,7 @@ var tests = []test{
 			host: "predefined-regex.path.path.example.com",
 			path: "/test1",
 		},
-		expected: "https://predefined-redirect.host.path.example.com/first/test1",
+		expected: "https://predefined-redirect.host.path.example.com/second/test1",
 	},
 	{
 		name: "Redirect a path record using predefined regex records",
@@ -48,7 +49,7 @@ var tests = []test{
 			host: "predefined-regex.path.path.example.com",
 			path: "/test1/test2",
 		},
-		expected: "https://predefined-redirect.host.path.example.com/second/test1/test2",
+		expected: "https://predefined-redirect.host.path.example.com/first/test1/test2",
 	},
 	{
 		name: "Fallback to \"to=\" when wildcard not found",
@@ -89,6 +90,168 @@ var tests = []test{
 			path: "/testing",
 		},
 		expected: "https://upstream.path.path.example.com",
+	},
+	{
+		name: "Fallback to root= when path is empty for custom regex",
+		args: data{
+			host: "numbered-regex.host.path.example.com",
+			path: "",
+		},
+		expected: "https://fallback.host.path.example.com",
+		comment:  "for: apt.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= field using numbered regex",
+		args: data{
+			host: "numbered-regex.host.path.example.com",
+			path: "/testing",
+		},
+		expected: "https://package.host.path.example.com/apt/testing?",
+		comment:  "for: apt.k8s.io",
+	},
+	{
+		name: "Redirect to root= when path is / for custom regex",
+		args: data{
+			host: "custom-numbered.host.path.example.com",
+			path: "/",
+		},
+		expected: "https://index.host.path.example.com",
+		comment:  "for: changelog.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= for custom regex using placeholders",
+		args: data{
+			host: "custom-numbered.host.path.example.com",
+			path: "/testing",
+		},
+		expected: "https://redirect.host.path.example.com/testing?",
+		comment:  "for: changelog.k8s.io",
+	},
+	{
+		name: "Fallback to root= when path is empty for predefined regexes",
+		args: data{
+			host: "predefined-numbered.host.path.example.com",
+			path: "/",
+		},
+		expected: "https://index.host.path.example.com",
+		comment:  "for: ci-test.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains digits for predefined regex",
+		args: data{
+			host: "predefined-numbered.host.path.example.com",
+			path: "/testing/1",
+		},
+		expected: "https://first-record.host.path.example.com/testing/1",
+		comment:  "for: ci-test.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains two slashes for predefined regex",
+		args: data{
+			host: "predefined-numbered.host.path.example.com",
+			path: "/testing/",
+		},
+		expected: "https://second-record.host.path.example.com/testing/",
+		comment:  "for: ci-test.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path is one part for predefined regex",
+		args: data{
+			host: "predefined-numbered.host.path.example.com",
+			path: "/testing",
+		},
+		expected: "https://third-record.host.path.example.com/testing",
+		comment:  "for: ci-test.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path is a semantic version",
+		args: data{
+			host: "predefined-multinumbered.host.path.example.com",
+			path: "/v0.0.1/",
+		},
+		expected: "https://first-record.host.path.example.com/v0.0.1/",
+		comment:  "for: dl.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains a word from custom regex",
+		args: data{
+			host: "predefined-multinumbered.host.path.example.com",
+			path: "/ci-cross/test",
+		},
+		expected: "https://second-record.host.path.example.com/ci-cross/test",
+		comment:  "for: dl.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains a word from custom regex",
+		args: data{
+			host: "predefined-multinumbered.host.path.example.com",
+			path: "/ci/test",
+		},
+		expected: "https://second-record.host.path.example.com/ci/test",
+		comment:  "for: dl.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains any character",
+		args: data{
+			host: "predefined-multinumbered.host.path.example.com",
+			path: "/notdefined",
+		},
+		expected: "https://third-record.host.path.example.com/notdefined",
+		comment:  "for: dl.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains a version",
+		args: data{
+			host: "predefined-version.host.path.example.com",
+			path: "/v0.0/beta",
+		},
+		expected: "https://first-record.host.path.example.com/v0.0/beta",
+		comment:  "for: docs.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains a version and word",
+		args: data{
+			host: "predefined-versionword.host.path.example.com",
+			path: "/v0.0/beta",
+		},
+		expected: "https://first-record.host.path.example.com/release-0.0/examples/beta",
+		comment:  "for: examples.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains brackets",
+		args: data{
+			host: "predefined-simpletospecific.host.path.example.com",
+			path: "/[test]/",
+		},
+		expected: "https://first-record.host.path.example.com/[test]/",
+		comment:  "for: git.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains brackets and words",
+		args: data{
+			host: "predefined-simpletospecific.host.path.example.com",
+			path: "/[test]/testing",
+		},
+		expected: "https://first-record.host.path.example.com/[test]/testing",
+		comment:  "for: git.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= using multiple predefined regexes",
+		args: data{
+			host: "predefined.host.path.example.com",
+			path: "/good-first-issue",
+		},
+		expected: "https://predefined-regex.host.path.example.com/4",
+		comment:  "for: go.k8s.io",
+	},
+	{
+		name: "Redirect to host record's to= when path contains release",
+		args: data{
+			host: "predefined-release.host.path.example.com",
+			path: "/v0.0.1/beta",
+		},
+		expected: "https://predefined-regex.host.path.example.com/v0.0.1/beta",
+		comment:  "for: releases.k8s.io",
 	},
 }
 

--- a/e2e/path/main.go
+++ b/e2e/path/main.go
@@ -74,6 +74,14 @@ var tests = []test{
 		},
 		expected: "https://fallback-to.path.path.example.com",
 	},
+	{
+		name: "Redirect using the use= field and upstream record",
+		args: data{
+			host: "sourcerecord.path.path.example.com",
+			path: "/testing",
+		},
+		expected: "https://upstream.path.path.example.com",
+	},
 }
 
 func main() {

--- a/e2e/path/zonefile
+++ b/e2e/path/zonefile
@@ -36,3 +36,9 @@ _redirect.fallback-refrom.path.path.example.com.       IN TXT "v=txtv0;type=path
 
 fallback-lenfrom.path.path.example.com.                IN A 172.20.10.2
 _redirect.fallback-lenfrom.path.path.example.com.      IN TXT "v=txtv0;type=path;from=$1$2$3;to=https://fallback-to.path.path.example.com;code=302"
+
+sourcerecord.path.path.example.com.                    IN A 172.20.10.2
+upstreamrecord.path.path.example.com.                  IN A 172.20.10.2
+_redirect.sourcerecord.path.path.example.com.          IN TXT "v=txtv0;type=path;use=_redirect.upstreamrecord.path.path.example.com"
+_redirect.upstreamrecord.path.path.example.com.        IN TXT "v=txtv0;type=path"
+_redirect._.upstreamrecord.path.path.example.com.      IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 

--- a/e2e/path/zonefile
+++ b/e2e/path/zonefile
@@ -10,41 +10,91 @@
 
 $TTL 1h
 
-example.com.                                           IN A 172.20.10.2
+example.com.                                                IN A 172.20.10.2
 
 
-noversion.path.path.example.com.                       IN A 172.20.10.2
-_redirect.noversion.path.path.example.com.             IN TXT "to=https://noversion-redirect.path.path.example.com;type=path"
+noversion.path.path.example.com.                            IN A 172.20.10.2
+_redirect.noversion.path.path.example.com.                  IN TXT "to=https://noversion-redirect.path.path.example.com;type=path"
 
-noroot.path.path.example.com.                          IN A 172.20.10.2
-_redirect.noroot.path.path.example.com.                IN TXT "v=txtv0;to=https://noroot-redirect.path.path.example.com;type=path;code=302"
+noroot.path.path.example.com.                               IN A 172.20.10.2
+_redirect.noroot.path.path.example.com.                     IN TXT "v=txtv0;to=https://noroot-redirect.path.path.example.com;type=path;code=302"
 
-predefined-regex.path.path.example.com.                IN A 172.20.10.2
-_redirect.predefined-regex.path.path.example.com.      IN TXT "v=txtv0;re=record;to=https://regex-redirect.path.path.example.com;type=path"
+predefined-regex.path.path.example.com.                     IN A 172.20.10.2
+_redirect.predefined-regex.path.path.example.com.           IN TXT "v=txtv0;re=record;to=https://regex-redirect.path.path.example.com;type=path"
 
-1.predefined-regex.path.path.example.com.              IN A 172.20.10.2
-_redirect.1.predefined-regex.path.path.example.com.    IN TXT "v=txtv0;re=\\/test1;to=https://predefined-redirect.host.path.example.com/first{1};type=host"
+1.predefined-regex.path.path.example.com.                   IN A 172.20.10.2
+_redirect.1.predefined-regex.path.path.example.com.         IN TXT "v=txtv0;re=\\/test1\\/test2;to=https://predefined-redirect.host.path.example.com/first{1};type=host"
 
-2.predefined-regex.path.path.example.com.              IN A 172.20.10.2
-_redirect.2.predefined-regex.path.path.example.com.    IN TXT "v=txtv0;re=\\/test1\\/test2;to=https://predefined-redirect.host.path.example.com/second{1};type=host"
+2.predefined-regex.path.path.example.com.                   IN A 172.20.10.2
+_redirect.2.predefined-regex.path.path.example.com.         IN TXT "v=txtv0;re=\\/test1;to=https://predefined-redirect.host.path.example.com/second{1};type=host"
 
-path.path.example.com.                                 IN A 172.20.10.2
-_redirect.path.path.example.com.                       IN TXT "v=txtv0;to=https://fallback-to.path.path.example.com;type=path;code=302"
+path.path.example.com.                                      IN A 172.20.10.2
+_redirect.path.path.example.com.                            IN TXT "v=txtv0;to=https://fallback-to.path.path.example.com;type=path;code=302"
 
-fallback-refrom.path.path.example.com.                 IN A 172.20.10.2
-_redirect.fallback-refrom.path.path.example.com.       IN TXT "v=txtv0;type=path;re=exist;from=$1$2;to=https://fallback-to.path.path.example.com;code=302"
+fallback-refrom.path.path.example.com.                      IN A 172.20.10.2
+_redirect.fallback-refrom.path.path.example.com.            IN TXT "v=txtv0;type=path;re=exist;from=$1$2;to=https://fallback-to.path.path.example.com;code=302"
 
-fallback-lenfrom.path.path.example.com.                IN A 172.20.10.2
-_redirect.fallback-lenfrom.path.path.example.com.      IN TXT "v=txtv0;type=path;from=$1$2$3;to=https://fallback-to.path.path.example.com;code=302"
+fallback-lenfrom.path.path.example.com.                     IN A 172.20.10.2
+_redirect.fallback-lenfrom.path.path.example.com.           IN TXT "v=txtv0;type=path;from=$1$2$3;to=https://fallback-to.path.path.example.com;code=302"
 
-sourcerecord.path.path.example.com.                    IN A 172.20.10.2
-upstreamrecord.path.path.example.com.                  IN A 172.20.10.2
-_redirect.sourcerecord.path.path.example.com.          IN TXT "v=txtv0;type=path;use=_redirect.upstreamrecord.path.path.example.com"
-_redirect.upstreamrecord.path.path.example.com.        IN TXT "v=txtv0;type=path"
-_redirect._.upstreamrecord.path.path.example.com.      IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 
+sourcerecord.path.path.example.com.                         IN A 172.20.10.2
+upstreamrecord.path.path.example.com.                       IN A 172.20.10.2
+_redirect.sourcerecord.path.path.example.com.               IN TXT "v=txtv0;type=path;use=_redirect.upstreamrecord.path.path.example.com"
+_redirect.upstreamrecord.path.path.example.com.             IN TXT "v=txtv0;type=path"
+_redirect._.upstreamrecord.path.path.example.com.           IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 
 
-srcrecord.path.path.example.com.                       IN A 172.20.10.2
-uprecord.path.path.example.com.                        IN A 172.20.10.2
-_redirect.srcrecord.path.path.example.com.             IN TXT "v=txtv0;type=path;use=_redirect.wrongupstream.path.path.example.com;use=_redirect.uprecord.path.path.example.com"
-_redirect.uprecord.path.path.example.com.              IN TXT "v=txtv0;type=path"
-_redirect._.uprecord.path.path.example.com.            IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 
+srcrecord.path.path.example.com.                            IN A 172.20.10.2
+uprecord.path.path.example.com.                             IN A 172.20.10.2
+_redirect.srcrecord.path.path.example.com.                  IN TXT "v=txtv0;type=path;use=_redirect.wrongupstream.path.path.example.com;use=_redirect.uprecord.path.path.example.com"
+_redirect.uprecord.path.path.example.com.                   IN TXT "v=txtv0;type=path"
+_redirect._.uprecord.path.path.example.com.                 IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 
+     
+numbered-regex.host.path.example.com.                       IN A 172.20.10.2
+_redirect.numbered-regex.host.path.example.com.             IN TXT "v=txtv0;type=path;root=https://fallback.host.path.example.com;re=^/(.*)?$"
+_redirect._.numbered-regex.host.path.example.com.           IN TXT "v=txtv0;type=host;to=https://package.host.path.example.com/apt/{1}"
+
+custom-numbered.host.path.example.com.                      IN A 172.20.10.2
+_redirect.custom-numbered.host.path.example.com.            IN TXT "v=txtv0;type=path;root=https://index.host.path.example.com;re=^/(.*)?$"
+_redirect._.custom-numbered.host.path.example.com.          IN TXT "v=txtv0;type=host;to=https://redirect.host.path.example.com/{1}"
+
+predefined-numbered.host.path.example.com.                  IN A 172.20.10.2
+_redirect.predefined-numbered.host.path.example.com.        IN TXT "v=txtv0;type=path;root=https://index.host.path.example.com;re=record"
+_redirect.1.predefined-numbered.host.path.example.com.      IN TXT "v=txtv0;type=host;to=https://first-record.host.path.example.com{1};re=^/(.*/\\d+)/?$"
+_redirect.2.predefined-numbered.host.path.example.com.      IN TXT "v=txtv0;type=host;to=https://second-record.host.path.example.com{1};re=^/(.*)/$"
+_redirect.3.predefined-numbered.host.path.example.com.      IN TXT "v=txtv0;type=host;to=https://third-record.host.path.example.com{1};re=^/(.*)$"
+
+predefined-multinumbered.host.path.example.com.             IN A 172.20.10.2
+_redirect.predefined-multinumbered.host.path.example.com.   IN TXT "v=txtv0;type=path;root=https://index.host.path.example.com;re=record"
+_redirect.1.predefined-multinumbered.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://first-record.host.path.example.com{1};re=^/(v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?/.*)$"
+_redirect.2.predefined-multinumbered.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://second-record.host.path.example.com/ci{2}/{3};re=^/ci(-cross)?/?(.*)$"
+_redirect.3.predefined-multinumbered.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://third-record.host.path.example.com{1};re=^/(.*)$"
+
+predefined-version.host.path.example.com.                   IN A 172.20.10.2
+_redirect.predefined-version.host.path.example.com.         IN TXT "v=txtv0;type=path;root=https://index.host.path.example.com;re=record"
+_redirect.1.predefined-version.host.path.example.com.       IN TXT "v=txtv0;type=host;to=https://first-record.host.path.example.com{1};re=^/v[0-9]+\.[0-9]+(/.*)?$"
+_redirect.2.predefined-version.host.path.example.com.       IN TXT "v=txtv0;type=host;to=https://second-record.host.path.example.com/docs/{1};re=^/(.*)$"
+
+predefined-versionword.host.path.example.com.               IN A 172.20.10.2
+_redirect.predefined-versionword.host.path.example.com.     IN TXT "v=txtv0;type=path;root=https://index.host.path.example.com;re=record"
+_redirect.1.predefined-versionword.host.path.example.com.   IN TXT "v=txtv0;type=host;to=https://first-record.host.path.example.com/release-{2}/examples{3};re=^/v([0-9]+\.[0-9]+)(/.*)?$"
+_redirect.2.predefined-versionword.host.path.example.com.   IN TXT "v=txtv0;type=host;to=https://second-record.host.path.example.com/{1};re=^/(.*)$"
+
+predefined-simpletospecific.host.path.example.com.             IN A 172.20.10.2
+_redirect.predefined-simpletospecific.host.path.example.com.   IN TXT "v=txtv0;type=path;root=https://index.host.path.example.com;re=record"
+_redirect.1.predefined-simpletospecific.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://first-record.host.path.example.com/{2}/{3};re=^/([^/]*)/(.*)$"
+_redirect.2.predefined-simpletospecific.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://second-record.host.path.example.com/{2};re=^/([^/]*)/?$"
+
+predefined.host.path.example.com.             IN A 172.20.10.2
+_redirect.predefined.host.path.example.com.   IN TXT "v=txtv0;type=path;root=https://index.host.path.example.com;re=record"
+_redirect.1.predefined.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://predefined-regex.host.path.example.com/1;re=^/api-review$"
+_redirect.2.predefined.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://predefined-regex.host.path.example.com/2;re=^/bot-commands$"
+_redirect.3.predefined.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://predefined-regex.host.path.example.com/3;re=^/github-labels$"
+_redirect.4.predefined.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://predefined-regex.host.path.example.com/4;re=^/good-first-issue$"
+_redirect.5.predefined.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://predefined-regex.host.path.example.com/5;re=^/help-wanted$"
+_redirect.6.predefined.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://predefined-regex.host.path.example.com/6;re=^/needs-ok-to-test$"
+_redirect.7.predefined.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://predefined-regex.host.path.example.com/7;re=^/oncall$"
+_redirect.8.predefined.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://predefined-regex.host.path.example.com/8;re=^/oncall-hotlist$"
+
+predefined-release.host.path.example.com.             IN A 172.20.10.2
+_redirect.predefined-release.host.path.example.com.   IN TXT "v=txtv0;type=path;root=https://index.host.path.example.com;re=record"
+_redirect.1.predefined-release.host.path.example.com. IN TXT "v=txtv0;type=host;to=https://predefined-regex.host.path.example.com/{2}{3};re=^/([^/]*)(/.*)?$"

--- a/e2e/path/zonefile
+++ b/e2e/path/zonefile
@@ -42,3 +42,9 @@ upstreamrecord.path.path.example.com.                  IN A 172.20.10.2
 _redirect.sourcerecord.path.path.example.com.          IN TXT "v=txtv0;type=path;use=_redirect.upstreamrecord.path.path.example.com"
 _redirect.upstreamrecord.path.path.example.com.        IN TXT "v=txtv0;type=path"
 _redirect._.upstreamrecord.path.path.example.com.      IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 
+
+srcrecord.path.path.example.com.                       IN A 172.20.10.2
+uprecord.path.path.example.com.                        IN A 172.20.10.2
+_redirect.srcrecord.path.path.example.com.             IN TXT "v=txtv0;type=path;use=_redirect.wrongupstream.path.path.example.com;use=_redirect.uprecord.path.path.example.com"
+_redirect.uprecord.path.path.example.com.              IN TXT "v=txtv0;type=path"
+_redirect._.uprecord.path.path.example.com.            IN TXT "v=txtv0;to=https://upstream.path.path.example.com;type=host;code=302" 

--- a/record.go
+++ b/record.go
@@ -28,6 +28,7 @@ type record struct {
 	To      string
 	Code    int
 	Type    string
+	Use     []string
 	Vcs     string
 	Website string
 	From    string
@@ -142,6 +143,13 @@ func ParseRecord(str string, w http.ResponseWriter, req *http.Request, c Config)
 		case strings.HasPrefix(l, "type="):
 			l = strings.TrimPrefix(l, "type=")
 			r.Type = l
+
+		case strings.HasPrefix(l, "use="):
+			l = strings.TrimPrefix(l, "use=")
+			if !strings.HasPrefix(l, "_redirect.") {
+				return record{}, fmt.Errorf("The given zone address is invalid")
+			}
+			r.Use = append(r.Use, l)
 
 		case strings.HasPrefix(l, "v="):
 			l = strings.TrimPrefix(l, "v=")

--- a/record.go
+++ b/record.go
@@ -197,17 +197,20 @@ func ParseRecord(str string, w http.ResponseWriter, req *http.Request, c Config)
 		r.Code = http.StatusFound
 	}
 
-	if r.Type == "" {
-		r.Type = "host"
-	}
+	// Only apply rules and default to records that doesn't point to a upstream record
+	if len(r.Use) == 0 {
+		if r.Type == "" {
+			r.Type = "host"
+		}
 
-	if r.Type == "host" && r.To == "" {
-		fallback(w, req, "global", http.StatusMovedPermanently, c)
-		return record{}, nil
-	}
+		if r.Type == "host" && r.To == "" {
+			fallback(w, req, "global", http.StatusMovedPermanently, c)
+			return record{}, nil
+		}
 
-	if !contains(c.Enable, r.Type) {
-		return record{}, fmt.Errorf("%s type is not enabled in configuration", r.Type)
+		if !contains(c.Enable, r.Type) {
+			return record{}, fmt.Errorf("%s type is not enabled in configuration", r.Type)
+		}
 	}
 
 	return r, nil

--- a/record.go
+++ b/record.go
@@ -77,13 +77,6 @@ func getRecord(host string, c Config, w http.ResponseWriter, r *http.Request) (r
 		}
 	}
 
-	if len(rec.Use) != 0 {
-		rec, err = rec.ReplaceRecord(c, w, r)
-		if err != nil {
-			return record{}, fmt.Errorf("Couldn't replace the record: %s", err.Error())
-		}
-	}
-
 	return rec, nil
 }
 
@@ -242,19 +235,21 @@ func ParseURI(uri string, w http.ResponseWriter, r *http.Request, c Config) stri
 	return url.String()
 }
 
-// ReplaceRecord will check all of the use= fields and sends a request to each
+// UpstreamRecord will check all of the use= fields and sends a request to each
 // upstream zone address and choses the first one that returns the final TXT
 // record
-func (rec *record) ReplaceRecord(c Config, w http.ResponseWriter, r *http.Request) (record, error) {
+func (rec *record) UpstreamRecord(c Config, w http.ResponseWriter, r *http.Request) (record, string, error) {
 	var upstreamRec record
 	var err error
 
+	// TODO: Check all the zones then return an error if no record found
 	for _, zone := range rec.Use {
 		upstreamRec, err = getRecord(zone, c, w, r)
 		if err != nil {
-			return record{}, fmt.Errorf("Couldn't query the upstream record: %s", err.Error())
+			return record{}, zone, fmt.Errorf("Couldn't query the upstream record: %s", err.Error())
 		}
+		return upstreamRec, zone, nil
 	}
 
-	return upstreamRec, nil
+	return record{}, "", fmt.Errorf("Couldn't find any records from upstream")
 }

--- a/record.go
+++ b/record.go
@@ -242,11 +242,10 @@ func (rec *record) UpstreamRecord(c Config, w http.ResponseWriter, r *http.Reque
 	var upstreamRec record
 	var err error
 
-	// TODO: Check all the zones then return an error if no record found
 	for _, zone := range rec.Use {
 		upstreamRec, err = getRecord(zone, c, w, r)
 		if err != nil {
-			return record{}, zone, fmt.Errorf("Couldn't query the upstream record: %s", err.Error())
+			continue
 		}
 		return upstreamRec, zone, nil
 	}

--- a/record.go
+++ b/record.go
@@ -128,6 +128,10 @@ func ParseRecord(str string, w http.ResponseWriter, req *http.Request, c Config)
 
 		case strings.HasPrefix(l, "root="):
 			l = strings.TrimPrefix(l, "root=")
+			l, err := parsePlaceholders(l, req, []string{})
+			if err != nil {
+				return record{}, err
+			}
 			l = ParseURI(l, w, req, c)
 			r.Root = l
 

--- a/record_test.go
+++ b/record_test.go
@@ -180,6 +180,28 @@ func TestParseRecord(t *testing.T) {
 			},
 		},
 		{
+			txtRecord: "v=txtv0;type=host;to=https://example.com;code=302;use=_redirect.example.com",
+			expected: record{
+				Version: "txtv0",
+				Type:    "host",
+				Code:    302,
+				Ref:     false,
+				To:      "https://example.com",
+				Use:     []string{"_redirect.example.com"},
+			},
+		},
+		{
+			txtRecord: "v=txtv0;type=host;to=https://example.com;use=_redirect.example.com;use=_redirect.example2.com",
+			expected: record{
+				Version: "txtv0",
+				Type:    "host",
+				Code:    302,
+				Ref:     false,
+				To:      "https://example.com",
+				Use:     []string{"_redirect.example.com", "_redirect.example2.com"},
+			},
+		},
+		{
 			// Commonly used http headers used for better real world testing.
 			// Taken from: https://www.whitehatsec.com/blog/list-of-http-response-headers/
 			txtRecord: `v=txtv0;type=path;code=302;
@@ -365,6 +387,13 @@ func TestParseRecord(t *testing.T) {
 			if test.expected.Headers[header] != val {
 				t.Errorf("Test %d: Expected %s Header to be '%s', got '%s'",
 					i, header, test.expected.Headers[header], val)
+			}
+		}
+
+		for i, zone := range r.Use {
+			if test.expected.Use[i] != zone {
+				t.Errorf("Test %d: Expected zone address to be '%s', got '%s'",
+					i, test.expected.Use[i], zone)
 			}
 		}
 	}

--- a/txtdirect.go
+++ b/txtdirect.go
@@ -185,6 +185,8 @@ func Redirect(w http.ResponseWriter, r *http.Request, c Config) error {
 		return nil
 	}
 
+	fmt.Println(rec)
+
 	// Add the upstream zone address from the use= fields to the request context
 	// and replace the source record with the upstream record
 	if len(rec.Use) != 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a few bugs in predefined regex feature and record parser.
Also adds E2E tests based on [k8s.io's nginx config](https://github.com/kubernetes/k8s.io/blob/master/k8s.io/configmap-nginx.yaml)

<!--
**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #0
-->

**Special notes for your reviewer**:
Only added parts of the config that had new regexes so we now have E2E tests for all of the unique regexes used in the nginx config.

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
