### PR TITLE
[make]: Show dirty versions in -version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BIN := txtdirect
 DOMAIN := c.txtdirect.org
 VERSION := $(shell cat ./VERSION)
+GITCOMMIT:=$(shell git describe --dirty --always)
 IMAGE := $(DOMAIN)/$(BIN):$(VERSION)
 CODEPATH := $(shell go list -m)
 
@@ -13,7 +14,7 @@ CONTAINER ?= $(BIN)
 
 build:
 	cd cmd/txtdirect && \
-	GO111MODULE=on CGO_ENABLED=0 GOARCH=$(BUILD_GOARCH) GOOS=$(BUILD_GOOS) go build -ldflags="-s -w -X $(CODEPATH)/txtdirectmain.TXTDirectVersion=$(VERSION)"
+	GO111MODULE=on CGO_ENABLED=0 GOARCH=$(BUILD_GOARCH) GOOS=$(BUILD_GOOS) go build -ldflags="-s -w -X $(CODEPATH)/txtdirectmain.TXTDirectVersion=$(VERSION) -X $(CODEPATH)/txtdirectmain.GitCommit=$(GITCOMMIT)"
 	mv cmd/txtdirect/txtdirect ./$(BIN)
 
 test:


### PR DESCRIPTION
**What this PR does / why we need it**:
Passes the git commit hash for dev builds via -ldflags.

**Which issue this PR fixes**:
fixes #328 

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
