### PR TITLE
(docs): remove non-printable 'no break space' char from testing readme

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -33,17 +33,17 @@ limitations under the License.
 - Create DNS record file named `example.test`
 
   ```
-  @                  3600 IN SOA      ns.example.test. domains.example.test. (
-                                        2017101010   ; serial
-                                        5m           ; refresh
-                                        5m           ; retry
-                                        1w           ; expire
-                                        12h    )     ; minimum
+  @                  3600 IN SOA      ns.example.test. domains.example.test. (
+                                        2017101010   ; serial
+                                        5m           ; refresh
+                                        5m           ; retry
+                                        1w           ; expire
+                                        12h    )     ; minimum
 
-  @                  86400 IN NS      ns.example.test.
-  @                  86400 IN NS      ns.example.test.
+  @                  86400 IN NS      ns.example.test.
+  @                  86400 IN NS      ns.example.test.
 
-  @                     60 IN A       127.0.0.1
+  @                     60 IN A       127.0.0.1
 
   _redirect             60 IN TXT     "v=txtv0;to=http://full-wildcard.worked.example.test;root=http://root.worked.example.test;type=path;code=302"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
If this is your first time, read our [contributing guidelines](/CONTRIBUTING.md).
-->
**What this PR does / why we need it**:

When I was going through the testing docs, I had a lot of trouble getting the example zone file to work with coredns. The syntax looked fine, so I used xxd to view the hex and noticed a lot of strange characters between the spaces used for formatting. [This character in particular](https://www.fileformat.info/info/unicode/char/a0/index.htm) seemed to break parsing in the downstream miekg/dns library. This PR removes those special characters so that noobies like me that copy and paste the example can get it working on their first try.